### PR TITLE
Make it possible to publish opensource repos in subdirectories

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -21,4 +21,11 @@ jobs:
       - uses: ./action-publish-code
         with:
           origin: ${{ github.repository }}
-          dirs: nixtest
+          # TODO: consider changing this action so that instead of listing the targets, it
+          # automatically scans all subdirectories and looks for a config file stating where
+          # that subdirectory should be published. If the config file lives in the subdir,
+          # the monorepo can be refactored and publishing still works. As things are today,
+          # if you relocate a subdirectory within the monorepo, you need to update this
+          # yaml for things to continue to work.
+          targets: >
+            nixtest

--- a/action-publish-code/action.yml
+++ b/action-publish-code/action.yml
@@ -8,11 +8,14 @@ inputs:
   origin:
     description: "Monorepo from which to publish code"
     required: true
-  dirs:
-    description: "Directories to publish. Target repo must already exist."
+  targets:
+    description: |
+      Repos to publish. Target repos must already exist.
+      Format is either <dir> or <dir>:<repo>. If <repo> is omitted, it is assumed to be the 
+      last subdirectory in <dir>.
     required: true
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/publish-code.sh ${{ inputs.origin }} ${{ inputs.dirs }}
+    - run: ${{ github.action_path }}/publish-code.sh ${{ inputs.origin }} ${{ inputs.targets }}
       shell: bash


### PR DESCRIPTION
Change the github action we use to publish repos from the opensource monorepo, to support publishing repos in subdirectories.

With this change we'll be able to publish `typeid/typeid-go` to a `typeid-go` repo. It also makes it possible to specify a custom name that does *not* match the directory name for cases when that's needed (example `dir1/dir2:reponame`).

A follow up PR will use this github action to publish the typeid code.