### PR TITLE
Clarify why the panic case won't trigger in the base32 package

### DIFF
--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -44,6 +44,12 @@ func (tid TypeID) String() string {
 
 func (tid TypeID) UUIDBytes() []byte {
 	b, err := base32.Decode(tid.suffix)
+
+	// Decode only fails if the suffix cannot be decoded for one of two reasons:
+	// 1. The suffix is not 26 characters long
+	// 2. The suffix contains characters that are not in the base32 alphabet
+	// We gurantee that the suffix is valid in the TypeID constructors, so this panic
+	// should never be reached.
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Clarify why the panic case won't trigger in the base32 package