### PR TITLE
Fix bug in publish script, improve messages

### DIFF
--- a/action-publish-code/publish-code.sh
+++ b/action-publish-code/publish-code.sh
@@ -58,16 +58,13 @@ for arg in "$@"; do
 	fi
 done
 
-exit 0
-
-
 for arg in "$@"; do
 	dir="${arg%:*}"
 	repo="${dir##*/}"
-	if [[ "$arg" != *":"* ]]; then
+	if [[ "$arg" = *":"* ]]; then
 		repo="${arg##*:}"
 	fi
-	echo "Publishing '${repo}' ..."
+	echo "Publishing dir '${dir}' to repo '${repo}' ..."
 
 	# Remove everything we don't want from the source repo:
 	# TODO: Rewrite using https://github.com/newren/git-filter-repo since filter-branch is no longer
@@ -101,6 +98,6 @@ for arg in "$@"; do
 	git for-each-ref --format="delete %(refname) %(objectname)" refs/original/ | git update-ref --stdin
 	git reset --hard HEAD
 
-	echo "[DONE] Published '${repo}' ..."
+	echo "[DONE] Published dir '${dir}' to repo '${repo}' ..."
 	echo -e "\n"
 done


### PR DESCRIPTION
The publish script had to bugs:
1. An unnecessary `exit 0` that ended the script early (it was added for debugging and I forgot to remove it)
2. The if statement to handle the case when the `:` is missing from an argument was inverted.

This PR fixes those issues and improves some of the printed messages.