### PR TITLE
Publish TySON to its own repo

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -32,3 +32,4 @@ jobs:
             typeid/typeid
             typeid/typeid-go
             typeid/typeid-sql
+            tyson


### PR DESCRIPTION
Publish TySON to its own repo (jetpack-io/tyson). I have it as private now, but once I verify the content looks good, I'll make it public.