### PR TITLE
Add friendly errors to TySON

### DIFF
--- a/tyson/README.md
+++ b/tyson/README.md
@@ -1,8 +1,8 @@
-# TySON
-### Typescript Object Notation: use TypeScript as a configuration language
+# TySON 🥊
+### Use TypeScript as a configuration language
 
 # What is it?
-TySON is a subset of TypeScript, chosen to be useful as an embeddable configuration
+TySON (TypeScript Object Notation) is a subset of TypeScript, chosen to be useful as an embeddable configuration
 language that generates JSON. You can think of it as JSON + types + functions using
 TypeScript syntax. TySON files use the `.tson` extension.
 
@@ -69,4 +69,6 @@ At the moment we offer:
 2. A command line tool, compiled as a single binary, that can parse and
    evaluate TySON files to JSON.
 
-Once we've solidified the spec, we plan to build libraries for other languages.
+Based on feedback from the community, we plan to add:
+1. A formal spec for TySON (once we feel confident that the feature set is stable).
+2. Implementations for other languages including `rust`.

--- a/tyson/cmd/tyson/cli/root.go
+++ b/tyson/cmd/tyson/cli/root.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.jetpack.io/tyson/msgerror"
 )
 
 func RootCmd() *cobra.Command {
@@ -28,7 +30,14 @@ func Execute(ctx context.Context, args []string) int {
 	cmd.SetArgs(args)
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
-		log.Println(err)
+		var msgError *msgerror.Error
+		if errors.As(err, &msgError) {
+			for _, msg := range msgError.Messages() {
+				fmt.Fprintln(os.Stderr, msg)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "[ERROR] %s\n", err)
+		}
 		return 1
 	}
 	return 0

--- a/tyson/internal/tsembed/tsembed.go
+++ b/tyson/internal/tsembed/tsembed.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/evanw/esbuild/pkg/api"
+	"go.jetpack.io/tyson/msgerror"
 )
 
 func Eval(entrypoint string) (goja.Value, error) {
@@ -57,7 +58,8 @@ func Build(entrypoint string) ([]byte, error) {
 	})
 
 	if len(bundle.Errors) > 0 {
-		return nil, fmt.Errorf("failed to build: %v", bundle.Errors)
+		msg := fmt.Sprintf("%d syntax errors when compiling %s", len(bundle.Errors), entrypoint)
+		return nil, msgerror.ErrFromMessages(msg, bundle.Errors)
 	}
 
 	if len(bundle.OutputFiles) != 1 {

--- a/tyson/msgerror/msgerror.go
+++ b/tyson/msgerror/msgerror.go
@@ -1,0 +1,45 @@
+package msgerror
+
+// TODO: there's an opportunity to bundle this code, together with:
+// - the code from esbuild that creates and formats error messages
+// - the error sanitization code we have in devbox
+// to opensource a library around friendly error messages
+// Something similar to rust's https://docs.rs/color-eyre/latest/color_eyre/
+import (
+	"errors"
+	"os"
+
+	"github.com/evanw/esbuild/pkg/api"
+	esbuild "github.com/evanw/esbuild/pkg/api"
+	"github.com/mattn/go-isatty"
+)
+
+type Error struct {
+	err      error
+	messages []esbuild.Message
+}
+
+func ErrFromMessages(toplevel string, messages []esbuild.Message) error {
+	return &Error{
+		err:      errors.New(toplevel),
+		messages: messages,
+	}
+}
+
+func (e *Error) Error() string {
+	return e.err.Error()
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+func (e *Error) Messages() []string {
+	isTerminal := isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+	formatted := api.FormatMessages(e.messages, api.FormatMessagesOptions{
+		Kind:          api.ErrorMessage,
+		Color:         isTerminal,
+		TerminalWidth: 100,
+	})
+	return formatted
+}


### PR DESCRIPTION
Now syntax errors show up as:

<img width="443" alt="image" src="https://github.com/jetpack-io/opensource/assets/279789/392eecc0-6534-4890-8304-7ddae4a5c778">
