### PR TITLE
Change goreleaser to use --clean flag

### DIFF
--- a/typeid/typeid/.github/workflows/release.yml
+++ b/typeid/typeid/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tyson/.github/workflows/release.yml
+++ b/tyson/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `--rm-dist` flag is deprecated in favor of `--clean`