### PR TITLE
Use .Tag instead of .Version in goreleaser

### DIFF
--- a/typeid/typeid/.goreleaser.yaml
+++ b/typeid/typeid/.goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
 archives:
   - files:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"

--- a/tyson/.goreleaser.yaml
+++ b/tyson/.goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
 archives:
   - files:
       - no-files-will-match-* # Glob that does not match to create archive with only binaries.
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
We used to use `.Version` in the goreleaser template, but that strips `v` from the version in the cases we want to use that. Switch to `.Tag` which leaves it intact.