### PR TITLE
Add installation instructions to README

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -43,20 +43,20 @@ We are looking for community contributions to implement TypeIDs in other languag
 ## Command-line Tool
 This repo includes a command-line tool for generating TypeIDs. To install it, run:
 
-```
-go install github.com/jetpack-io/typeid
+```bash
+curl -fsSL https://get.jetpack.io/typeid | bash
 ```
 
 To generate a new TypeID, run:
 
-```
+```console
 $ typeid prefix
 prefix_01h2xcejqtf2nbrexx3vqjhp41
 ```
 
 To decode an existing TypeID into a UUID run:
   
-```
+```console
 $ typeid decode prefix_01h2xcejqtf2nbrexx3vqjhp41
 type: prefix
 uuid: 0188bac7-4afa-78aa-bc3b-bd1eef28d881
@@ -64,7 +64,7 @@ uuid: 0188bac7-4afa-78aa-bc3b-bd1eef28d881
 
 And to encode an existing UUID into a TypeID run:
 
-```
+```console
 $ typeid encode prefix 0188bac7-4afa-78aa-bc3b-bd1eef28d881
 prefix_01h2xcejqtf2nbrexx3vqjhp41
 ```

--- a/tyson/README.md
+++ b/tyson/README.md
@@ -126,6 +126,22 @@ for configuration. But when writting tools in other languages like `go`, what he
 us back was the lack of native libraries for evaluating TypeScript-based
 configs. We decided to build TySON to address this issue.
 
+## Command Line Tool
+TySON comes with a command line tool that can be used to convert TySON files to
+JSON. To install it, run:
+
+```bash
+curl -fsSL https://get.jetpack.io/tyson | bash
+```
+
+To convert the file `input.tson` into JSON, run:
+
+```bash
+tyson eval input.tson
+```
+
+The resulting JSON will be printed to stdout.
+
 ## Next Steps
 We're sharing TySON as an early developer preview, to get feedback from the
 community before we solidify the spec.


### PR DESCRIPTION
Add installations instructions to both `typeid` and `tyson` README files.