### PR TITLE
Add 'new' to example in README

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -50,7 +50,7 @@ curl -fsSL https://get.jetpack.io/typeid | bash
 To generate a new TypeID, run:
 
 ```console
-$ typeid prefix
+$ typeid new prefix
 prefix_01h2xcejqtf2nbrexx3vqjhp41
 ```
 


### PR DESCRIPTION
This fixes the example in the readme. It's supposed to be `typeid new`