### PR TITLE
Adds string validation before creating a typeid via FromString

### DIFF
--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -80,8 +80,14 @@ func From(prefix string, suffix string) (TypeID, error) {
 }
 
 func FromString(s string) (TypeID, error) {
-	parts := strings.SplitN(s, "_", 2)
-	return From(parts[0], parts[1])
+	switch parts := strings.SplitN(s, "_", 2); len(parts) {
+	case 1:
+		return From("", parts[0])
+	case 2:
+		return From(parts[0], parts[1])
+	default:
+		return Nil, fmt.Errorf("invalid typeid: %s", s)
+	}
 }
 
 func FromUUID(prefix string, uidStr string) (TypeID, error) {


### PR DESCRIPTION
Migrated from https://github.com/jetpack-io/typeid-go/pull/1

Compared to the original PR this one tolerates typeids without prefix. It also considers a `[prefix]_[suffix]_[random]` invalid, which I'm assuming it's the right thing to do, specially to support symmetry when going back and forth from strings to typeids.