### PR TITLE
add github.com/broothie/typeid-ruby to `README.md`

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -48,11 +48,11 @@ Implementations should adhere to the formal [specification](./spec).
 | -------- | ------ | ---------------------- |
 | [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | @TenCoKaciStromy | Not Yet |
 | [Python](https://github.com/akhundMurad/typeid-python) | @akhundMurad | Yes, 2023-06-30 |
+| [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 | [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |
 | [Rust](https://github.com/conrad/type-safe-id) | @conrad | Not Yet |
 | [Swift](https://github.com/Frizlab/swift-typeid) | @Frizlab | Yes, on 2023-06-30 |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts) | @ongteckwu | Yes, on 2023-06-30 |
-| [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 
 We are looking for community contributions to implement TypeIDs in other languages.
 

--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -52,6 +52,7 @@ Implementations should adhere to the formal [specification](./spec).
 | [Rust](https://github.com/conrad/type-safe-id) | @conrad | Not Yet |
 | [Swift](https://github.com/Frizlab/swift-typeid) | @Frizlab | Yes, on 2023-06-30 |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts) | @ongteckwu | Yes, on 2023-06-30 |
+| [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 
 We are looking for community contributions to implement TypeIDs in other languages.
 


### PR DESCRIPTION
Adding a Ruby implementation of typeid, [typeid-ruby](https://github.com/broothie/typeid-ruby). It's been tested against the provided `valid.yml` and `invalid.yml` files. It does not come with a CLI, not sure if that's a requirement!