### PR TITLE
Add TypeID Java implementation to README

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -47,6 +47,7 @@ Implementations should adhere to the formal [specification](./spec).
 | Language | Author | Validated Against Spec? |
 | -------- | ------ | ---------------------- |
 | [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | @TenCoKaciStromy | Not Yet |
+| [Java](https://github.com/fxlae/typeid-java) | @fxlae | Yes, on 2023-07-02 |
 | [Python](https://github.com/akhundMurad/typeid-python) | @akhundMurad | Yes, 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 | [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |


### PR DESCRIPTION
There is a [spec test class](https://github.com/fxlae/typeid-java/blob/main/src/test/java/de/fxlae/typeid/SpecTest.java) that specifically uses the two files (valid.yml/invalid.yml) for validation against the specification. I marked the entry in the table as "validated" and hope that's ok, if not please just let me know.