### PR TITLE
Add `BombenProdukt/typeid` for `PHP` to `README.md`

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -50,6 +50,7 @@ Implementations should adhere to the formal [specification](./spec).
 | [C# (.Net Standard 2.1)](https://github.com/cbuctok/typeId) | @cbuctok | Yes, on 2023-07-03 |
 | [Elixir](https://github.com/sloanelybutsurely/typeid-elixir) | [@sloanelybutsurely](https://github.com/sloanelybutsurely) | Yes, 2023-07-02 |
 | [Java](https://github.com/fxlae/typeid-java) | @fxlae | Yes, on 2023-07-02 |
+| [PHP](https://github.com/BombenProdukt/typeid) | [@BombenProdukt](https://github/BombenProdukt) | Yes, on 2023-07-03 |
 | [Python](https://github.com/akhundMurad/typeid-python) | @akhundMurad | Yes, 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 | [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |


### PR DESCRIPTION
I've begun an implementation for PHP, which you can find at https://github.com/BombenProdukt/typeid. The encoding and decoding implementation is based on https://github.com/jetpack-io/typeid-js. At present, it passes all encodings as per https://github.com/jetpack-io/typeid/blob/main/spec/valid.yml. We are running the tests directly against the `valid.yml` and `invalid.yml` files to promptly detect any failures. ~Tests for the `invalid.yml` file are still missing, but I plan to add them in the coming days as time allows.~