### PR TITLE
Statically typed version of TypeIDs using generics

### DIFF
--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -43,7 +43,7 @@ import (
 )
 
 func example() {
-  tid := typeid.New[UserIDType]()
+  tid := typeid.New[UserID]()
   fmt.Println(tid)
 }
 ```

--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -30,8 +30,9 @@ import (
   typeid "go.jetpack.io/typeid/typed"
 )
 
-type UserIDType struct{}
-func (UserIDType) Type() string { return "user" }
+type userPrefix struct{}
+func (userPrefix) Type() string { return "user" }
+type UserID struct { typeid.TypeID[userPrefix] }
 ```
 
 And now use those types to generate TypeIDs:

--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -34,7 +34,7 @@ type UserIDType struct{}
 func (UserIDType) Type() string { return "user" }
 ```
 
-And now uses those types to generate TypeIDs:
+And now use those types to generate TypeIDs:
 
 ```go
 import (

--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -1,6 +1,6 @@
 # TypeID Go
 ### A golang implementation of [TypeIDs](https://github.com/jetpack-io/typeid)
-![License: Apache 2.0](https://img.shields.io/github/license/jetpack-io/typeid-go)
+![License: Apache 2.0](https://img.shields.io/github/license/jetpack-io/typeid-go) [![Go Reference](https://pkg.go.dev/badge/go.jetpack.io/typeid.svg)](https://pkg.go.dev/go.jetpack.io/typeid)
 
 TypeIDs are a modern, **type-safe**, globally unique identifier based on the upcoming
 UUIDv7 standard. They provide a ton of nice properties that make them a great choice
@@ -8,3 +8,56 @@ as the primary identifiers for your data in a database, APIs, and distributed sy
 Read more about TypeIDs in their [spec](https://github.com/jetpack-io/typeid).
 
 This particular implementation provides a go library for generating and parsing TypeIDs.
+
+## Installation
+
+To add this library as a dependency in your go module, run:
+
+```bash
+go get go.jetpack.io/typeid
+```
+
+## Usage
+This library provides both a statically typed and a dynamically typed version of TypeIDs.
+
+The statically typed version that lives under the `typed` package is the recommended version,
+because it makes it possible for the go compiler itself to enforce type safety.
+
+To use it, first define your TypeID types:
+
+```go
+import (
+  typeid "go.jetpack.io/typeid/typed"
+)
+
+type UserIDType struct{}
+func (UserIDType) Type() string { return "user" }
+```
+
+And now uses those types to generate TypeIDs:
+
+```go
+import (
+  typeid "go.jetpack.io/typeid/typed"
+)
+
+func example() {
+  tid := typeid.New[UserIDType]()
+  fmt.Println(tid)
+}
+```
+
+If you don't want static types, you can use the dynamic version instead:
+  
+```go
+import (
+  "go.jetpack.io/typeid/typeid"
+)
+
+func example() {
+  tid := typeid.New("user")
+  fmt.Println(tid)
+}
+```
+
+For the full documentation, see this package's [godoc](https://pkg.go.dev/go.jetpack.io/typeid).

--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -20,8 +20,8 @@ go get go.jetpack.io/typeid
 ## Usage
 This library provides both a statically typed and a dynamically typed version of TypeIDs.
 
-The statically typed version that lives under the `typed` package is the recommended version,
-because it makes it possible for the go compiler itself to enforce type safety.
+The statically typed version that lives under the `typed` package, it makes it possible for
+the go compiler itself to enforce type safety.
 
 To use it, first define your TypeID types:
 

--- a/typeid/typeid-go/README.md
+++ b/typeid/typeid-go/README.md
@@ -20,7 +20,7 @@ go get go.jetpack.io/typeid
 ## Usage
 This library provides both a statically typed and a dynamically typed version of TypeIDs.
 
-The statically typed version that lives under the `typed` package, it makes it possible for
+The statically typed version lives under the `typed` package. It makes it possible for
 the go compiler itself to enforce type safety.
 
 To use it, first define your TypeID types:

--- a/typeid/typeid-go/doc.go
+++ b/typeid/typeid-go/doc.go
@@ -1,0 +1,7 @@
+// TypeIDs are a modern, **type-safe**, globally unique identifier based on the upcoming
+// UUIDv7 standard. They provide a ton of nice properties that make them a great choice
+// as the primary identifiers for your data in a database, APIs, and distributed systems.
+// Read more about TypeIDs in their [spec](https://github.com/jetpack-io/typeid).
+
+// This particular implementation provides a go library for generating and parsing TypeIDs
+package typeid

--- a/typeid/typeid-go/typed/doc.go
+++ b/typeid/typeid-go/typed/doc.go
@@ -2,26 +2,32 @@
 //
 // To use it, define your own ID types that implement the IDType interface:
 //
-//	type UserIDType struct{}
-//	func (UserIDType) Type() string { return "user" }
+//	type userPrefix struct{}
+//	func (userPrefix) Type() string { return "user" }
+//	type UserID struct {
+//		typeid.TypeID[userPrefix]
+//	}
 //
-//	type AccountIDType struct{}
-//	func (AccountIDType) Type() string { return "account" }
+//	type accountPrefix struct{}
+//	func (accountPrefix) Type() string { return "account" }
+//	type AccountID struct {
+//		typeid.TypeID[accountPrefix]
+//	}
 //
 // And now you can use your IDTypes via generics. For example, to create a
 // new ID of type user:
 //
-//	  import (
-//		   typeid "go.jetpack.io/typeid/typed"
-//		 )
+//	import (
+//		typeid "go.jetpack.io/typeid/typed"
+//	)
 //
-//	  user_id, _ := typeid.New[UserIDType]()
+//	user_id, _ := typeid.New[UserID]()
 //
 // Because this implementation uses generics, the go compiler itself will
 // enforce that you can't mix up your ID types. For example, a function with
 // the signature:
 //
-//	func f(id typed.TypeID[UserIDType]) {}
+//	func f(id UserID) {}
 //
-// Will fail to compile if passed an id of type AccountIDType.
+// Will fail to compile if passed an id of type AccountID.
 package typed

--- a/typeid/typeid-go/typed/doc.go
+++ b/typeid/typeid-go/typed/doc.go
@@ -11,7 +11,10 @@
 // And now you can use your IDTypes via generics. For example, to create a
 // new ID of type user:
 //
-//		import (typeid "go.jetpack.io/typeid/typed")
+//	  import (
+//		   typeid "go.jetpack.io/typeid/typed"
+//		 )
+//
 //	  user_id, _ := typeid.New[UserIDType]()
 //
 // Because this implementation uses generics, the go compiler itself will

--- a/typeid/typeid-go/typed/doc.go
+++ b/typeid/typeid-go/typed/doc.go
@@ -1,0 +1,24 @@
+// Package typed implements a statically checked version of TypeIDs
+//
+// To use it, define your own ID types that implement the IDType interface:
+//
+//	type UserIDType struct{}
+//	func (UserIDType) Type() string { return "user" }
+//
+//	type AccountIDType struct{}
+//	func (AccountIDType) Type() string { return "account" }
+//
+// And now you can use your IDTypes via generics. For example, to create a
+// new ID of type user:
+//
+//		import (typeid "go.jetpack.io/typeid/typed")
+//	  user_id, _ := typeid.New[UserIDType]()
+//
+// Because this implementation uses generics, the go compiler itself will
+// enforce that you can't mix up your ID types. For example, a function with
+// the signature:
+//
+//	func f(id typed.TypeID[UserIDType]) {}
+//
+// Will fail to compile if passed an id of type AccountIDType.
+package typed

--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -9,7 +9,7 @@ import (
 // IDType is an interface used to represent a statically checked ID type.
 // Example:
 // type UserIDType struct{}
-// func (UserIDType) Prefix() string { return "user" }
+// func (UserIDType) Type() string { return "user" }
 type IDType interface {
 	Type() string
 }

--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -1,0 +1,115 @@
+package typed
+
+import (
+	"fmt"
+
+	untyped "go.jetpack.io/typeid"
+)
+
+// IDType is an interface used to represent a statically checked ID type.
+// Example:
+// type UserIDType struct{}
+// func (UserIDType) Prefix() string { return "user" }
+type IDType interface {
+	Type() string
+}
+
+// TypeID is a unique identifier with a given type as defined by the TypeID spec
+type TypeID[T IDType] untyped.TypeID
+
+// New returns a new TypeID with a random suffix and the given type.
+func New[T IDType]() (TypeID[T], error) {
+	var prefix T
+	tid, err := untyped.New(prefix.Type())
+	if err != nil {
+		// Clients should ignore the id value when an error is present, but just
+		// in case, construct a "nil" id of the given type.
+		return Nil[T](), err
+	}
+	return (TypeID[T])(tid), nil
+}
+
+// Nil returns the null typeid of the given type.
+func Nil[T IDType]() TypeID[T] {
+	var prefix T
+	return TypeID[T](untyped.Must(untyped.From(prefix.Type(), "00000000000000000000000000")))
+}
+
+// Type returns the type prefix of the TypeID
+func (tid TypeID[T]) Type() string {
+	return untyped.TypeID(tid).Type()
+}
+
+// Suffix returns the suffix of the TypeID in it's canonical base32 representation.
+func (tid TypeID[T]) Suffix() string {
+	return untyped.TypeID(tid).Suffix()
+}
+
+// String returns the TypeID in it's canonical string representation of the form:
+// <prefix>_<suffix> where <suffix> is the canonical base32 representation of the UUID
+func (tid TypeID[T]) String() string {
+	return untyped.TypeID(tid).String()
+}
+
+// UUIDBytes decodes the TypeID's suffix as a UUID and returns it's bytes
+func (tid TypeID[T]) UUIDBytes() []byte {
+	return untyped.TypeID(tid).UUIDBytes()
+}
+
+// UUID decode the TypeID's suffix as a UUID and returns it as a hex formatted string
+func (tid TypeID[T]) UUID() string {
+	return untyped.TypeID(tid).UUID()
+}
+
+// From returns a new TypeID of the given type using the provided suffix
+func From[T IDType](suffix string) (TypeID[T], error) {
+	var prefix T
+	tid, err := untyped.From(prefix.Type(), suffix)
+	if err != nil {
+		return Nil[T](), err
+	}
+	return (TypeID[T])(tid), nil
+}
+
+// FromString parses a TypeID from the given string. Returns an error if the
+// string is not a valid TypeID, OR if the type prefix does not match the
+// expected type.
+func FromString[T IDType](s string) (TypeID[T], error) {
+	var prefix T
+	tid, err := untyped.FromString(s)
+	if err != nil {
+		return Nil[T](), err
+	}
+	if tid.Type() != prefix.Type() {
+		return Nil[T](), fmt.Errorf("invalid type, expected %s but got %s", prefix.Type(), tid.Type())
+	}
+	return (TypeID[T])(tid), nil
+}
+
+// FromUUID returns a new TypeID of the given type using the provided UUID
+func FromUUID[T IDType](uuid string) (TypeID[T], error) {
+	var prefix T
+	tid, err := untyped.FromUUID(prefix.Type(), uuid)
+	if err != nil {
+		return Nil[T](), err
+	}
+	return (TypeID[T])(tid), nil
+}
+
+// FromUUIDBytes returns a new TypeID of the given type using the provided UUID bytes
+func FromUUIDBytes[T IDType](uuid []byte) (TypeID[T], error) {
+	var prefix T
+	tid, err := untyped.FromUUIDBytes(prefix.Type(), uuid)
+	if err != nil {
+		return Nil[T](), err
+	}
+	return (TypeID[T])(tid), nil
+}
+
+// Must panics if the given error is non-nil, otherwise it returns the given TypeID
+func Must[T IDType](tid TypeID[T], err error) TypeID[T] {
+	if err != nil {
+		panic(err)
+	}
+	return tid
+}

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -6,17 +6,21 @@ import (
 	typeid "go.jetpack.io/typeid/typed"
 )
 
-type UserIDType struct{}
+type userPrefix struct{}
 
-func (UserIDType) Type() string { return "user" }
+func (userPrefix) Type() string { return "user" }
 
-type AccountIDType struct{}
+type UserID struct{ typeid.TypeID[userPrefix] }
 
-func (AccountIDType) Type() string { return "account" }
+type accountPrefix struct{}
+
+func (accountPrefix) Type() string { return "account" }
+
+type AccountID struct{ typeid.TypeID[accountPrefix] }
 
 func Example() {
-	user_id, _ := typeid.New[UserIDType]()
-	account_id, _ := typeid.New[AccountIDType]()
+	user_id, _ := typeid.New[UserID]()
+	account_id, _ := typeid.New[AccountID]()
 	// Each ID should have the correct type prefix:
 	fmt.Printf("User ID prefix: %s\n", user_id.Type())
 	fmt.Printf("Account ID prefix: %s\n", account_id.Type())
@@ -26,5 +30,5 @@ func Example() {
 	// Output:
 	// User ID prefix: user
 	// Account ID prefix: account
-	// typed.TypeID[go.jetpack.io/typeid/typed_test.UserIDType] != typed.TypeID[go.jetpack.io/typeid/typed_test.AccountIDType]
+	// typed.TypeID[go.jetpack.io/typeid/typed_test.UserID] != typed.TypeID[go.jetpack.io/typeid/typed_test.AccountID]
 }

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -1,0 +1,30 @@
+package typed_test
+
+import (
+	"fmt"
+
+	typeid "go.jetpack.io/typeid/typed"
+)
+
+type UserIDType struct{}
+
+func (UserIDType) Type() string { return "user" }
+
+type AccountIDType struct{}
+
+func (AccountIDType) Type() string { return "account" }
+
+func Example() {
+	user_id, _ := typeid.New[UserIDType]()
+	account_id, _ := typeid.New[AccountIDType]()
+	// Each ID should have the correct type prefix:
+	fmt.Printf("User ID prefix: %s\n", user_id.Type())
+	fmt.Printf("Account ID prefix: %s\n", account_id.Type())
+	// The compiler considers their go types to be different:
+	fmt.Printf("%T != %T\n", user_id, account_id)
+
+	// Output:
+	// User ID prefix: user
+	// Account ID prefix: account
+	// typed.TypeID[go.jetpack.io/typeid/typed_test.UserIDType] != typed.TypeID[go.jetpack.io/typeid/typed_test.AccountIDType]
+}

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -9,28 +9,36 @@ import (
 	"go.jetpack.io/typeid/base32"
 )
 
+// TypeID is a unique identifier with a given type as defined by the TypeID spec
 type TypeID struct {
 	prefix string
 	suffix string
 }
 
+// Nil represents an the null TypeID
 var Nil = TypeID{
 	prefix: "",
 	suffix: "00000000000000000000000000",
 }
 
+// New returns a new TypeID with the given prefix and a random suffix.
+// If you want to create an id without a prefix, pass an empty string.
 func New(prefix string) (TypeID, error) {
 	return From(prefix, "")
 }
 
+// Type returns the type prefix of the TypeID
 func (tid TypeID) Type() string {
 	return tid.prefix
 }
 
+// Suffix returns the suffix of the TypeID in it's canonical base32 representation.
 func (tid TypeID) Suffix() string {
 	return tid.suffix
 }
 
+// String returns the TypeID in it's canonical string representation of the form:
+// <prefix>_<suffix> where <suffix> is the canonical base32 representation of the UUID
 func (tid TypeID) String() string {
 	if tid.prefix == "" {
 		return tid.suffix
@@ -38,6 +46,7 @@ func (tid TypeID) String() string {
 	return tid.prefix + "_" + tid.Suffix()
 }
 
+// UUIDBytes decodes the TypeID's suffix as a UUID and returns it's bytes
 func (tid TypeID) UUIDBytes() []byte {
 	b, err := base32.Decode(tid.suffix)
 
@@ -52,10 +61,14 @@ func (tid TypeID) UUIDBytes() []byte {
 	return b
 }
 
+// UUID decodes the TypeID's suffix as a UUID and returns it as a hex string
 func (tid TypeID) UUID() string {
 	return uuid.FromBytesOrNil(tid.UUIDBytes()).String()
 }
 
+// From returns a new TypeID with the given prefix and suffix.
+// If suffix is the empty string, a random suffix will be generated.
+// If you want to create an id without a prefix, pass an empty string as the prefix.
 func From(prefix string, suffix string) (TypeID, error) {
 	if err := validatePrefix(prefix); err != nil {
 		return Nil, err
@@ -80,6 +93,7 @@ func From(prefix string, suffix string) (TypeID, error) {
 
 }
 
+// FromString parses a TypeID from a string of the form <prefix>_<suffix>
 func FromString(s string) (TypeID, error) {
 	switch parts := strings.SplitN(s, "_", 2); len(parts) {
 	case 1:
@@ -94,6 +108,7 @@ func FromString(s string) (TypeID, error) {
 	}
 }
 
+// FromUUID encodes the given UUID (in hex string form) as a TypeID with the given prefix.
 func FromUUID(prefix string, uidStr string) (TypeID, error) {
 	uid, err := uuid.FromString(uidStr)
 	if err != nil {
@@ -103,11 +118,15 @@ func FromUUID(prefix string, uidStr string) (TypeID, error) {
 	return From(prefix, suffix)
 }
 
+// FromUUID encodes the given UUID (in byte form) as a TypeID with the given prefix.
 func FromUUIDBytes(prefix string, bytes []byte) (TypeID, error) {
 	uidStr := uuid.FromBytesOrNil(bytes).String()
 	return FromUUID(prefix, uidStr)
 }
 
+// Must returns a TypeID if the error is nil, otherwise panics.
+// Often used with New() to create a TypeID in a single line as follows:
+// tid := Must(New("prefix"))
 func Must(tid TypeID, err error) TypeID {
 	if err != nil {
 		panic(err)

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -1,4 +1,4 @@
-package typeid
+package typeid_test
 
 import (
 	_ "embed"
@@ -6,22 +6,23 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.jetpack.io/typeid"
 	"gopkg.in/yaml.v2"
 )
 
 func ExampleNew() {
-	tid := Must(New("prefix"))
+	tid := typeid.Must(typeid.New("prefix"))
 	fmt.Printf("New typeid: %s\n", tid)
 }
 
 func ExampleNew_withoutPrefix() {
-	tid := Must(New(""))
+	tid := typeid.Must(typeid.New(""))
 	fmt.Printf("New typeid without prefix: %s\n", tid)
 }
 
 func ExampleFromString() {
-	tid := Must(FromString("prefix_00041061050r3gg28a1c60t3gf"))
-	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Type(), tid.suffix)
+	tid := typeid.Must(typeid.FromString("prefix_00041061050r3gg28a1c60t3gf"))
+	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Type(), tid.Suffix())
 	// Output:
 	// Prefix: prefix
 	// Suffix: 00041061050r3gg28a1c60t3gf
@@ -41,7 +42,7 @@ func TestInvalidPrefix(t *testing.T) {
 
 	for _, td := range testdata {
 		t.Run(td.name, func(t *testing.T) {
-			_, err := New(td.input)
+			_, err := typeid.New(td.input)
 			if err == nil {
 				t.Errorf("Expected error for invalid prefix: %s", td.input)
 			}
@@ -66,7 +67,7 @@ func TestInvalidSuffix(t *testing.T) {
 
 	for _, td := range testdata {
 		t.Run(td.name, func(t *testing.T) {
-			_, err := From("prefix", td.input)
+			_, err := typeid.From("prefix", td.input)
 			if err == nil {
 				t.Errorf("Expected error for invalid suffix: %s", td.input)
 			}
@@ -93,7 +94,7 @@ func TestInvalidTestdata(t *testing.T) {
 
 	for _, td := range testdata {
 		t.Run(td.Name, func(t *testing.T) {
-			_, err := FromString(td.Tid)
+			_, err := typeid.FromString(td.Tid)
 			if err == nil {
 				t.Errorf("Expected error for invalid typeid: %s", td.Tid)
 			}
@@ -105,8 +106,8 @@ func TestEncodeDecode(t *testing.T) {
 	// Generate a bunch of random typeids, encode and decode from a string
 	// and make sure the result is the same as the original.
 	for i := 0; i < 1000; i++ {
-		tid := Must(New("prefix"))
-		decoded, err := FromString(tid.String())
+		tid := typeid.Must(typeid.New("prefix"))
+		decoded, err := typeid.FromString(tid.String())
 		if err != nil {
 			t.Error(err)
 		}
@@ -117,8 +118,8 @@ func TestEncodeDecode(t *testing.T) {
 
 	// Repeat with the empty prefix:
 	for i := 0; i < 1000; i++ {
-		tid := Must(New(""))
-		decoded, err := FromString(tid.String())
+		tid := typeid.Must(typeid.New(""))
+		decoded, err := typeid.FromString(tid.String())
 		if err != nil {
 			t.Error(err)
 		}
@@ -143,13 +144,13 @@ func TestSpecialValues(t *testing.T) {
 	for _, td := range testdata {
 		t.Run(td.name, func(t *testing.T) {
 			// Values should be equal if we start by parsing the typeid
-			tid := Must(FromString(td.tid))
+			tid := typeid.Must(typeid.FromString(td.tid))
 			if td.uuid != tid.UUID() {
 				t.Errorf("Expected %s, got %s", td.uuid, tid.UUID())
 			}
 
 			// Values should be equal if we start by parsing the uuid
-			tid = Must(FromUUID("", td.uuid))
+			tid = typeid.Must(typeid.FromUUID("", td.uuid))
 			if td.tid != tid.String() {
 				t.Errorf("Expected %s, got %s", td.tid, tid.String())
 			}
@@ -178,7 +179,7 @@ func TestValidTestdata(t *testing.T) {
 
 	for _, td := range testdata {
 		t.Run(td.Name, func(t *testing.T) {
-			tid := Must(FromString(td.Tid))
+			tid := typeid.Must(typeid.FromString(td.Tid))
 			if td.Uuid != tid.UUID() {
 				t.Errorf("Expected %s, got %s", td.Uuid, tid.UUID())
 			}
@@ -191,13 +192,13 @@ func TestValidTestdata(t *testing.T) {
 
 func BenchmarkNew(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_ = Must(New("prefix"))
+		_ = typeid.Must(typeid.New("prefix"))
 	}
 }
 
 func BenchmarkEncodeDecode(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		tid := Must(New("prefix"))
-		_ = Must(FromString(tid.String()))
+		tid := typeid.Must(typeid.New("prefix"))
+		_ = typeid.Must(typeid.FromString(tid.String()))
 	}
 }

--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -39,24 +39,23 @@ Implementations should adhere to the formal [specification](./spec).
 | Language | Status |
 | -------- | ------ |
 | [Go](https://github.com/jetpack-io/typeid-go) | ✓ Implemented |
-| Python | ... Coming Soon |
 | [SQL](https://github.com/jetpack-io/typeid-sql) | ✓ Implemented |
 | [TypeScript](https://github.com/jetpack-io/typeid-js) | ✓ Implemented |
 
 ### Community Provided Implementations
 | Language | Author | Validated Against Spec? |
 | -------- | ------ | ---------------------- |
-| [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | @TenCoKaciStromy | Not Yet |
-| [C# (.Net Standard 2.1)](https://github.com/cbuctok/typeId) | @cbuctok | Yes, on 2023-07-03 |
-| [Elixir](https://github.com/sloanelybutsurely/typeid-elixir) | [@sloanelybutsurely](https://github.com/sloanelybutsurely) | Yes, 2023-07-02 |
-| [Java](https://github.com/fxlae/typeid-java) | @fxlae | Yes, on 2023-07-02 |
-| [PHP](https://github.com/BombenProdukt/typeid) | [@BombenProdukt](https://github/BombenProdukt) | Yes, on 2023-07-03 |
-| [Python](https://github.com/akhundMurad/typeid-python) | @akhundMurad | Yes, 2023-06-30 |
+| [C# (.Net)](https://github.com/TenCoKaciStromy/typeid-dotnet) | [@TenCoKaciStromy](https://github.com/TenCoKaciStromy) | Not Yet |
+| [C# (.Net Standard 2.1)](https://github.com/cbuctok/typeId) | [@cbuctok](https://github.com/cbuctok) | Yes, on 2023-07-03 |
+| [Elixir](https://github.com/sloanelybutsurely/typeid-elixir) | [@sloanelybutsurely](https://github.com/sloanelybutsurely) | Yes, on 2023-07-02 |
+| [Java](https://github.com/fxlae/typeid-java) | [@fxlae](https://github.com/fxlae) | Yes, on 2023-07-02 |
+| [PHP](https://github.com/BombenProdukt/typeid) | [@BombenProdukt](https://github.com/BombenProdukt) | Yes, on 2023-07-03 |
+| [Python](https://github.com/akhundMurad/typeid-python) | [@akhundMurad](https://github.com/akhundMurad) | Yes, on 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
-| [Rust](https://github.com/alisa101rs/typeid-rs) | @alisa101rs | Not Yet |
-| [Rust](https://github.com/conradludgate/type-safe-id) | @conradludgate | Yes, on 2023-07-01 |
-| [Swift](https://github.com/Frizlab/swift-typeid) | @Frizlab | Yes, on 2023-06-30 |
-| [TypeScript](https://github.com/ongteckwu/typeid-ts) | @ongteckwu | Yes, on 2023-06-30 |
+| [Rust](https://github.com/alisa101rs/typeid-rs) | [@alisa101rs](https://github.com/alisa101rs) | Not Yet |
+| [Rust](https://github.com/conradludgate/type-safe-id) | [@conradludgate](https://github.com/conradludgate) | Yes, on 2023-07-01 |
+| [Swift](https://github.com/Frizlab/swift-typeid) | [@Frizlab](https://github.com/Frizlab) | Yes, on 2023-06-30 |
+| [TypeScript](https://github.com/ongteckwu/typeid-ts) | [@ongteckwu](https://github.com/ongteckwu) | Yes, on 2023-06-30 |
 
 We are looking for community contributions to implement TypeIDs in other languages.
 


### PR DESCRIPTION
Cleans up the godocs for the `typeid` go module.
Adds a statically typed version using generics.