### PR TITLE
[typeid-sql] Change order of fields in typeid_generate()

### DIFF
--- a/typeid/typeid-sql/sql/typeid.sql
+++ b/typeid/typeid-sql/sql/typeid.sql
@@ -14,7 +14,7 @@ create or replace function typeid_generate(kind text)
 returns typeid
 as $$
 begin
-  return (uuid_generate_v7(), kind);
+  return (kind, uuid_generate_v7());
 end
 $$
 language plpgsql


### PR DESCRIPTION
Change order of fields in `typeid_generate()` so that it matches the custom type definition. Addresses https://github.com/jetpack-io/typeid-sql/issues/2 as reported by @shellscape