### PR TITLE
[typeid-js] Use generics for TypeID<T> resulting in stronger type checking

### DIFF
--- a/typeid/typeid-js/README.md
+++ b/typeid/typeid-js/README.md
@@ -43,20 +43,36 @@ import { typeid } from 'typeid-js';
 const tid = typeid();
 ```
 
-In addition to the `typeid()` function, there's also a `TypeID` class that can
-be used to encode/decode from other formats.
+The return type of `typeid("prefix")` is `TypeID<"prefix">`, which lets you use
+TypeScript's type checking to ensure you are passing the correct type prefix to
+functions that expect it.
+
+For example, you can create a function that only accepts TypeIDs of type `user`:
+```typescript
+import { typeid, TypeID } from 'typeid-js';
+
+function doSomethingWithUserID(id: TypeID<"user">) {
+  // ...
+}
+```
+
+In addition to the `typeid()` function, the `TypeID` class has additional methods
+to encode/decode from other formats.
 
 For example, to parse an existing typeid from a string:
 ```typescript
 import { TypeID } from 'typeid-js';
 
-const tid = TypeID.fromString("prefix_00041061050r3gg28a1c60t3gf");
+// The asType() call is optional, but it converts to type TypeID<"prefix"> instead
+// of TypeID<string>
+const tid = TypeID.fromString("prefix_00041061050r3gg28a1c60t3gf").asType("prefix");
 ```
 
 To encode an existing UUID as a TypeID:
 ```typescript
 import { TypeID } from 'typeid-js';
 
+// In this case TypeID<"prefix"> is inferred from the first argument
 const tid = TypeID.fromUUID("prefix", "00000000-0000-0000-0000-000000000000");
 ```
 

--- a/typeid/typeid-js/package.json
+++ b/typeid/typeid-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeid-js",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official implementation of the TypeID specification in TypeScript. TypeIDs are type-safe, K-sortable, and globally unique identifiers inspired by Stripe IDs",
   "keywords": [
     "typeid",

--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -18,8 +18,9 @@ function isValidPrefix(str: string): boolean {
   return true;
 };
 
-export class TypeID {
-  constructor(private prefix: string = "", private suffix: string = "") {
+export class TypeID<const T extends string> {
+
+  constructor(private prefix: T | "" = "", private suffix: string = "") {
     if (!isValidPrefix(prefix)) {
       throw new Error("Invalid prefix. Must be at most 63 ascii letters [a-z]");
     }
@@ -45,7 +46,7 @@ export class TypeID {
     const unused = decode(this.suffix);
   }
 
-  public getType(): string {
+  public getType(): T {
     return this.prefix;
   }
 
@@ -69,29 +70,33 @@ export class TypeID {
     return `${this.prefix}_${this.suffix}`;
   }
 
-  static fromString(str: string): TypeID {
+  static fromString<const T extends string>(str: string): TypeID<T> {
     const parts = str.split("_");
     if (parts.length === 1) {
-      return new TypeID("", parts[0]);
+      return new TypeID<T>("", parts[0]);
     }
     if (parts.length === 2) {
       if (parts[0] === "") {
         throw new Error(`Invalid TypeID. Prefix cannot be empty when there's a separator: ${str}`);
       }
-      return new TypeID(parts[0], parts[1]);
+      return new TypeID<T>(parts[0], parts[1]);
     }
     throw new Error(`Invalid TypeID string: ${str}`);
   }
 
-  static fromUUIDBytes(prefix: string = "", bytes: Uint8Array = new Uint8Array(16)): TypeID {
+  static fromUUIDBytes<const T extends string>(prefix: T, bytes: Uint8Array): TypeID<T> {
     const suffix = encode(bytes);
     return new TypeID(prefix, suffix);
   }
 
-  static fromUUID(prefix: string = "", uuid: string = ""): TypeID {
+  static fromUUID<const T extends string>(prefix: T, uuid: string): TypeID<T> {
     const suffix = encode(parseUUID(uuid));
     return new TypeID(prefix, suffix);
   }
 }
 
-export const typeid = (prefix: string = "", suffix: string = "") => new TypeID(prefix, suffix);
+export const typeid = <const T extends string>(prefix: T | "" = "", suffix: string = "") => new TypeID(prefix, suffix) as TypeID<T>;
+
+
+var myval = typeid("foo");
+myval = typeid();

--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -19,8 +19,7 @@ function isValidPrefix(str: string): boolean {
 };
 
 export class TypeID<const T extends string> {
-
-  constructor(private prefix: T | "" = "", private suffix: string = "") {
+  constructor(private prefix: T = "" as T, private suffix: string = "") {
     if (!isValidPrefix(prefix)) {
       throw new Error("Invalid prefix. Must be at most 63 ascii letters [a-z]");
     }
@@ -73,13 +72,13 @@ export class TypeID<const T extends string> {
   static fromString<const T extends string>(str: string): TypeID<T> {
     const parts = str.split("_");
     if (parts.length === 1) {
-      return new TypeID<T>("", parts[0]);
+      return new TypeID<T>("" as T, parts[0]);
     }
     if (parts.length === 2) {
       if (parts[0] === "") {
         throw new Error(`Invalid TypeID. Prefix cannot be empty when there's a separator: ${str}`);
       }
-      return new TypeID<T>(parts[0], parts[1]);
+      return new TypeID<T>(parts[0] as T, parts[1]);
     }
     throw new Error(`Invalid TypeID string: ${str}`);
   }
@@ -95,8 +94,5 @@ export class TypeID<const T extends string> {
   }
 }
 
-export const typeid = <const T extends string>(prefix: T | "" = "", suffix: string = "") => new TypeID(prefix, suffix) as TypeID<T>;
-
-
-var myval = typeid("foo");
-myval = typeid();
+export const typeid = <const T extends string>(prefix: T = "" as T, suffix: string = "") =>
+  new TypeID(prefix, suffix) as TypeID<T>;

--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -19,7 +19,7 @@ function isValidPrefix(str: string): boolean {
 };
 
 export class TypeID<const T extends string> {
-  constructor(private prefix: T = "" as T, private suffix: string = "") {
+  constructor(private prefix: T, private suffix: string = "") {
     if (!isValidPrefix(prefix)) {
       throw new Error("Invalid prefix. Must be at most 63 ascii letters [a-z]");
     }
@@ -51,6 +51,14 @@ export class TypeID<const T extends string> {
 
   public getSuffix(): string {
     return this.suffix;
+  }
+
+  public asType<const U extends string>(prefix: U): TypeID<U> {
+    const self = this as unknown as TypeID<U>;
+    if (self.prefix !== prefix) {
+      throw new Error(`Cannot convert TypeID of type ${self.prefix} to type ${prefix}`);
+    }
+    return self;
   }
 
   public toUUIDBytes(): Uint8Array {
@@ -94,5 +102,9 @@ export class TypeID<const T extends string> {
   }
 }
 
-export const typeid = <const T extends string>(prefix: T = "" as T, suffix: string = "") =>
-  new TypeID(prefix, suffix) as TypeID<T>;
+export function typeid<T extends string>(): TypeID<''>;
+export function typeid<T extends string>(prefix: T): TypeID<T>;
+export function typeid<T extends string>(prefix: T, suffix: string): TypeID<T>;
+export function typeid<T extends string>(prefix: T = "" as T, suffix: string = ""): TypeID<T> {
+  return new TypeID(prefix, suffix);
+}

--- a/typeid/typeid-js/test/typeid.test.ts
+++ b/typeid/typeid-js/test/typeid.test.ts
@@ -42,6 +42,20 @@ describe('TypeID', () => {
     });
   });
 
+  describe('asType', () => {
+    it('should return the type specified by the given prefix', () => {
+      const prefix = 'prefix';
+      const tid = typeid(prefix);
+      const narrowed = tid.asType(prefix);
+      expect(tid).toEqual(narrowed);
+    });
+
+    it('should throw an error on prefix mismatch', () => {
+      const tid = typeid('foo');
+      expect(() => tid.asType('bar')).toThrow('Cannot convert TypeID of type foo to type bar');
+    });
+  });
+
   describe('toString', () => {
     it('should return a string representation', () => {
       const prefix = "test";

--- a/typeid/typeid-sql/README.md
+++ b/typeid/typeid-sql/README.md
@@ -17,7 +17,7 @@ We recommend copying the SQL scripts into your migrations directory and using th
 migration tool of your choice. For example, [Flyway](https://flywaydb.org/), or
 [Liquibase](https://www.liquibase.org/).
 
-Noe that this repo is using Supabase as a way to easily start a Postgres instance
+Note that this repo is using Supabase as a way to easily start a Postgres instance
 for development and testing, but you do **not** need to use Supabase for this
 implementation to work – simply use the Postgres instance of your choice.
 


### PR DESCRIPTION
Change the type of the TypeID class to `TypeID<T>` where `T` is the expected prefix.

Update the types of the different methods appropriately. Add an `asType()` method as suggested by @xprnio for cases
when the compiler can't figure out the exact type and we need to do narrowing manually. This is most commonly needed
when parsing a TypeID from a string:
```
TypeID.fromString("prefix_00041061050r3gg28a1c60t3gf").asType("prefix");
```

Add a test for `asType` and update README appropriately