### PR TITLE
[typeid-go] Implement Text Marshaling

### DIFF
--- a/typeid/typeid-go/encoding.go
+++ b/typeid/typeid-go/encoding.go
@@ -1,0 +1,27 @@
+package typeid
+
+import "encoding"
+
+// TODO: Define a standardized binary encoding for typeids in the spec
+// and use that to implement encoding.BinaryMarshaler and encoding.BinaryUnmarshaler
+
+var _ encoding.TextMarshaler = (*TypeID)(nil)
+var _ encoding.TextUnmarshaler = (*TypeID)(nil)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// It parses a TypeID from a string using the same logic as FromString()
+func (tid *TypeID) UnmarshalText(text []byte) error {
+	parsed, err := FromString(string(text))
+	if err != nil {
+		return err
+	}
+	*tid = parsed
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// It encodes a TypeID as a string using the same logic as String()
+func (tid TypeID) MarshalText() (text []byte, err error) {
+	encoded := tid.String()
+	return []byte(encoded), nil
+}

--- a/typeid/typeid-go/encoding_test.go
+++ b/typeid/typeid-go/encoding_test.go
@@ -1,0 +1,26 @@
+package typeid_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.jetpack.io/typeid"
+)
+
+func TestJSON(t *testing.T) {
+	str := "prefix_00041061050r3gg28a1c60t3gf"
+	tid := typeid.Must(typeid.FromString(str))
+
+	encoded, err := json.Marshal(tid)
+	assert.NoError(t, err)
+	assert.Equal(t, `"`+str+`"`, string(encoded))
+
+	var decoded typeid.TypeID
+	err = json.Unmarshal(encoded, &decoded)
+	assert.NoError(t, err)
+
+	assert.Equal(t, tid, decoded)
+	assert.Equal(t, str, decoded.String())
+}

--- a/typeid/typeid-go/typed/encoding.go
+++ b/typeid/typeid-go/typed/encoding.go
@@ -1,0 +1,19 @@
+package typed
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// It parses a TypeID from a string using the same logic as FromString()
+func (tid *TypeID[T]) UnmarshalText(text []byte) error {
+	parsed, err := FromString[T](string(text))
+	if err != nil {
+		return err
+	}
+	*tid = parsed
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// It encodes a TypeID as a string using the same logic as String()
+func (tid TypeID[T]) MarshalText() (text []byte, err error) {
+	encoded := tid.String()
+	return []byte(encoded), nil
+}


### PR DESCRIPTION
This implements the `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces as suggested in https://github.com/jetpack-io/typeid-go/issues/4

The PR also adds a test that demonstrates JSON encoding/decoding works correctly.

CC: @Karitham