### PR TITLE
Add the strong_id crate as a Rust implementation of TypeID

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -55,6 +55,7 @@ Implementations should adhere to the formal [specification](./spec).
 | [Python](https://github.com/akhundMurad/typeid-python) | [@akhundMurad](https://github.com/akhundMurad) | Yes, on 2023-06-30 |
 | [Ruby](https://github.com/broothie/typeid-ruby) | [@broothie](https://github.com/broothie) | Yes, on 2023-06-30 |
 | [Rust](https://github.com/conradludgate/type-safe-id) | [@conradludgate](https://github.com/conradludgate) | Yes, on 2023-07-01 |
+| [Rust](https://github.com/johnnynotsolucky/strong_id) | [@johnnynotsolucky](https://github.com/johnnynotsolucky) | Yes, on 2023-07-13 |
 | [Swift](https://github.com/Frizlab/swift-typeid) | [@Frizlab](https://github.com/Frizlab) | Yes, on 2023-06-30 |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts) | [@ongteckwu](https://github.com/ongteckwu) | Yes, on 2023-06-30 |
 | [Zig](https://github.com/tensorush/zig-typeid) | [@tensorush](https://github.com/tensorush) | Yes, on 2023-07-05 |


### PR DESCRIPTION
I have a Rust crate which implements TypeID-like behavior for unsigned ints and UUIDs. It is compliant with the TypeID spec when the "typeid" feature is enabled, which is the same as enabling both "uuid" and "uuid-v7" features.

I've included a dedicated crate which pulls the spec files and tests encoding/decoding the values: https://github.com/johnnynotsolucky/strong_id/tree/main/tests/typeid_spec

There is also a github workflow which runs on a 6 hour cron to confirm that the implementation is still valid: https://github.com/johnnynotsolucky/strong_id/blob/main/.github/workflows/typeid_spec.yaml

This crate takes a different approach in that it uses macros to generate TypeIDs so that we can have compile-time validation of prefix rules.