### PR TITLE
Adds in native typeid equality overloading

### DIFF
--- a/typeid/typeid-sql/sql/03_typeid.sql
+++ b/typeid/typeid-sql/sql/03_typeid.sql
@@ -95,3 +95,39 @@ end
 $$
 language plpgsql
 immutable;
+
+-- Enables direct textual equality checks. This enables direct querying in pSQL without
+-- having to have clients know about db column internals- e.g. using the users table
+-- example in example.sql:
+--
+-- Query:
+-- SELECT * FROM users u WHERE u.id = 'user_01h455vb4pex5vsknk084sn02q'
+--
+-- Result:
+-- "(user,018962e7-3a6d-7290-b088-5c4e3bdf918c)",Ben Bitdiddle,ben@bitdiddle.com
+--
+-- Note: This also has the nice benefit of playing very well with generators
+-- such as Hibernate/JPA/JDBC/r2dbc, as you'll be able to do direct equality checks
+-- in repositories, such as for r2dbc:
+--
+-- @Query(value = "SELECT u.id, u.name, u.email FROM users u WHERE u.id = :id")
+-- Mono<UserEntity> findByPassedInTypeId(@Param("id") Mono<String> typeId); // user_01h455vb4pex5vsknk084sn02q
+--
+-- Note: This function only has to ever be declared once, and will work for any domains that use
+-- the original typeid type (e.g. this function gets called when querying for a user_id even though
+-- we never explicitly override the quality operator for a user_id.
+CREATE OR REPLACE FUNCTION compare_type_id_equality(lhs_id typeid, rhs_id VARCHAR)
+    RETURNS BOOLEAN AS $$
+SELECT lhs_id = typeid_parse(rhs_id);
+$$ LANGUAGE SQL IMMUTABLE;
+
+CREATE OPERATOR = (
+    LEFTARG = typeid,
+    RIGHTARG = VARCHAR,
+    PROCEDURE = compare_type_id_equality,
+    COMMUTATOR = =,
+    NEGATOR = !=,
+    HASHES,
+    MERGES
+    );
+


### PR DESCRIPTION
Hey, I came across some behavior in a Java SpringBoot + postgres setup, and found what looks like a pretty generic solution that could be handy for other people.

Essentially, I needed the ability to query in java for the DB records by a given typeid, and instead of needing to drop down into the raw `databaseclient` to call the `typeid_parse` stored procedure that's already defined here, I could define an operator overload instead, which would allow me to just query a given DB table by the serialized type_id instead.

I added a comment in the actual `.sql` file, but let me know if you'd like me to make any changes to this PR.