### PR TITLE
Warn contributors to use OSS monorepo

### DIFF
--- a/nixtest/.github/pull_request_template.md
+++ b/nixtest/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.

--- a/typeid/typeid-go/.github/pull_request_template.md
+++ b/typeid/typeid-go/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.

--- a/typeid/typeid-js/.github/pull_request_template.md
+++ b/typeid/typeid-js/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.

--- a/typeid/typeid-sql/.github/pull_request_template.md
+++ b/typeid/typeid-sql/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.

--- a/typeid/typeid/.github/pull_request_template.md
+++ b/typeid/typeid/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.

--- a/tyson/.github/pull_request_template.md
+++ b/tyson/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# ⚠️ Submit PRs in our opensource monorepo instead ⚠️
+
+This repository is automatically published from our opensource monorepo:
+https://github.com/jetpack-io/opensource
+
+If you want to contribute code changes to this project, please submit your
+PR via the monorepo.


### PR DESCRIPTION
Add a PR template that automatically warns contributors to send PRs via the opensource monorepo instead.