### PR TITLE
[typeid] Add a T-SQL implementation in the README.md

### DIFF
--- a/typeid/typeid/README.md
+++ b/typeid/typeid/README.md
@@ -59,6 +59,7 @@ Implementations should adhere to the formal [specification](./spec).
 | [Rust](https://github.com/johnnynotsolucky/strong_id) | [@johnnynotsolucky](https://github.com/johnnynotsolucky) | Yes, on 2023-07-13 |
 | [Scala](https://github.com/ant8e/uuid4cats-effect) | [@ant8e](https://github.com/ant8e) | Yes, on 2023-07-14 |
 | [Swift](https://github.com/Frizlab/swift-typeid) | [@Frizlab](https://github.com/Frizlab) | Yes, on 2023-07-07 |
+| [T-SQL](https://github.com/uniteeio/typeid_tsql) | [@uniteeio](https://github.com/uniteeio) | Yes, on 2023-08-25 |
 | [TypeScript](https://github.com/ongteckwu/typeid-ts) | [@ongteckwu](https://github.com/ongteckwu) | Yes, on 2023-06-30 |
 | [Zig](https://github.com/tensorush/zig-typeid) | [@tensorush](https://github.com/tensorush) | Yes, on 2023-07-05 |
 


### PR DESCRIPTION
Hello,

We added an T-SQL naive implementation (allowing to migrate, create default constraint etc) in SQL Server.
It respects the specs (we can decode it using your CLI)

Regards