### PR TITLE
[envsec] added caching for jwks public keys

### DIFF
--- a/envsec/internal/auth/cache.go
+++ b/envsec/internal/auth/cache.go
@@ -70,7 +70,7 @@ func saveJWKSCache(url string, cacheDir string, path string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	// make sure cache dir exists before creating the file
-	if os.MkdirAll(cacheDir, os.ModePerm); err != nil {
+	if err = os.MkdirAll(cacheDir, os.ModePerm); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	out, err := os.Create(path)

--- a/envsec/internal/auth/cache.go
+++ b/envsec/internal/auth/cache.go
@@ -69,6 +69,7 @@ func saveJWKSCache(url string, path string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	defer resp.Body.Close()
 
 	out, err := os.Create(path)
 	if err != nil {

--- a/envsec/internal/auth/cache.go
+++ b/envsec/internal/auth/cache.go
@@ -79,7 +79,6 @@ func saveJWKSCache(url string, path string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	fmt.Printf("resp.body: %s \n\n", jwks)
 	_, err = out.Write(jwks)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/envsec/internal/auth/jwkscache.go
+++ b/envsec/internal/auth/jwkscache.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/pkg/errors"
+)
+
+const dirName = ".jetpack"
+const jwksFileName = "jwks.json"
+const cacheDuration = 1 * time.Hour
+
+func (a *Authenticator) fetchJWKSWithCache() (*keyfunc.JWKS, error) {
+	jwksURL := fmt.Sprintf("https://%s/.well-known/jwks.json", a.Domain)
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	path := filepath.Join(wd, dirName, jwksFileName)
+	// check Cache if miss, jwksJSON will be empty
+	jwksJSON, err := readJWKSCache(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if jwksJSON == nil { // cache miss
+		// save new keys to cache
+		err = saveJWKSCache(jwksURL, path)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	jwks, err := keyfunc.NewJSON(jwksJSON)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return jwks, nil
+}
+
+func readJWKSCache(path string) ([]byte, error) {
+	fileInfo, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	modificationTime := fileInfo.ModTime()
+	current := time.Now()
+	if current.After(modificationTime.Add(cacheDuration)) {
+		return nil, nil
+	}
+	byteContent, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil
+	}
+	return byteContent, nil
+}
+
+func saveJWKSCache(url string, path string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("error while making fetching jwks: %w", err)
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error while creating cache for jwks: %w", err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("error while copying data: %w", err)
+	}
+
+	return nil
+}

--- a/envsec/internal/auth/user.go
+++ b/envsec/internal/auth/user.go
@@ -4,10 +4,8 @@
 package auth
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
 )
@@ -81,16 +79,11 @@ func (u *User) OrgID() string {
 }
 
 func (a *Authenticator) verifyAndBuildUser(tokens *tokenSet) (*User, error) {
-	jwksURL := fmt.Sprintf(
-		"https://%s/.well-known/jwks.json",
-		a.Domain,
-	)
-	// TODO: Cache this
-	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
+
+	jwks, err := a.fetchJWKSWithCache()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-
 	accessToken, err := jwt.Parse(tokens.AccessToken, jwks.Keyfunc)
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
## Summary
a few implementation decisions:
- The caching is under `auth` package. 
- Cache duration is 1 hour. I check file's last modified. That means a user can manually modify the file to keep the cache going. But because it is client side any approach will have its flaws. So I rather discuss before implementing a solution for it.
- file name is `<domain>.jwks.json`
- readJWKSCache() checks file age as well as reading the cached file. Returns nil in case of cache miss.
- saveJWKSCache() downloads jwks.json and saves the values in a file and returns it. To prevent an extra read cache call after saving the cache.


## How was it tested?
- devbox run build
- envsec ls