### PR TITLE
[envsec] fix ls envname bug

### DIFF
--- a/envsec/internal/envcli/exec.go
+++ b/envsec/internal/envcli/exec.go
@@ -34,7 +34,7 @@ func execCmd() *cobra.Command {
 			commandToRun := exec.Command("/bin/sh", "-c", commandString)
 
 			// Default environment to fetch values from is DEV
-			envNames := []string{"DEV"}
+			envNames := []string{"dev"}
 			// If a specific environment was set by the user, then just use that one.
 			if cmd.Flags().Changed(environmentFlagName) {
 				envNames = []string{strings.ToLower(cmdCfg.EnvId.EnvName)}

--- a/envsec/internal/envcli/exec.go
+++ b/envsec/internal/envcli/exec.go
@@ -37,7 +37,7 @@ func execCmd() *cobra.Command {
 			envNames := []string{"DEV"}
 			// If a specific environment was set by the user, then just use that one.
 			if cmd.Flags().Changed(environmentFlagName) {
-				envNames = []string{cmdCfg.EnvId.EnvName}
+				envNames = []string{strings.ToLower(cmdCfg.EnvId.EnvName)}
 			}
 			envId := envsec.EnvId{
 				OrgId:     cmdCfg.EnvId.OrgId,

--- a/envsec/internal/envcli/ls.go
+++ b/envsec/internal/envcli/ls.go
@@ -34,7 +34,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 			// Populate the valid Environments
-			envNames := []string{"DEV", "PROD", "STAGING"}
+			envNames := []string{"dev", "prod", "staging"}
 			// If a specific environment was set by the user, then just use that one.
 			if cmd.Flags().Changed(environmentFlagName) {
 				envNames = []string{strings.ToLower(cmdCfg.EnvId.EnvName)}

--- a/envsec/internal/envcli/ls.go
+++ b/envsec/internal/envcli/ls.go
@@ -45,7 +45,7 @@ func listCmd() *cobra.Command {
 				envId := envsec.EnvId{
 					OrgId:     cmdCfg.EnvId.OrgId,
 					ProjectId: cmdCfg.EnvId.ProjectId,
-					EnvName:   envName,
+					EnvName:   strings.ToLower(envName),
 				}
 				envVars, err := cmdCfg.Store.List(cmd.Context(), envId)
 				if err != nil {

--- a/envsec/internal/envcli/ls.go
+++ b/envsec/internal/envcli/ls.go
@@ -4,6 +4,8 @@
 package envcli
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec"
@@ -35,7 +37,7 @@ func listCmd() *cobra.Command {
 			envNames := []string{"DEV", "PROD", "STAGING"}
 			// If a specific environment was set by the user, then just use that one.
 			if cmd.Flags().Changed(environmentFlagName) {
-				envNames = []string{cmdCfg.EnvId.EnvName}
+				envNames = []string{strings.ToLower(cmdCfg.EnvId.EnvName)}
 			}
 
 			// TODO: parallelize


### PR DESCRIPTION
## Summary
All envsec commands (except `ls` and `exec`) use `strings.ToLower()` when passing `EnvId.EnvName` that means environments like "DEV" and "PROD" becomes "dev" and "prod" in aws ssm.

This creates a bug where you can set a secret with `envsec set key=value` but in `envsec ls` not be able to see that key. This change might be backwards incompatible, but I don't know how envsec at its current state is usable unless someone specifies the environment everytime they `set` and `ls`

![Screenshot 2023-08-30 at 6 53 31 PM](https://github.com/jetpack-io/opensource/assets/22227661/ef936f3c-2412-418c-8854-a49729cfb3f1)

## How was it tested?
- `envsec set testkey=testvalue`
- `envsec ls`
