### PR TITLE
[envsec] Allow custom path

### DIFF
--- a/envsec/envsec.go
+++ b/envsec/envsec.go
@@ -5,9 +5,12 @@ package envsec
 
 import (
 	"context"
+	"path"
 
 	"github.com/pkg/errors"
 )
+
+const PATH_PREFIX = "/jetpack-data/env"
 
 // Uniquely identifies an environment in which we store environment variables.
 type EnvId struct {
@@ -64,6 +67,8 @@ func NewStore(ctx context.Context, config Config) (Store, error) {
 
 type Config interface {
 	IsEnvStoreConfig() bool
+	VarPath(envId EnvId, varName string) string
+	PathNamespace(envId EnvId) string
 }
 
 type SSMConfig struct {
@@ -79,4 +84,17 @@ var _ Config = (*SSMConfig)(nil)
 
 func (c *SSMConfig) IsEnvStoreConfig() bool {
 	return true
+}
+
+func (c *SSMConfig) VarPath(envId EnvId, varName string) string {
+	return path.Join(
+		c.PathNamespace(envId),
+		envId.ProjectId,
+		envId.EnvName,
+		varName,
+	)
+}
+
+func (c *SSMConfig) PathNamespace(envId EnvId) string {
+	return path.Join(PATH_PREFIX, envId.OrgId)
 }

--- a/envsec/ssm_store.go
+++ b/envsec/ssm_store.go
@@ -13,8 +13,7 @@ import (
 )
 
 type SSMStore struct {
-	config *SSMConfig
-	store  *parameterStore
+	store *parameterStore
 }
 
 // SSMStore implements interface Store (compile-time check)
@@ -26,8 +25,7 @@ func newSSMStore(ctx context.Context, config *SSMConfig) (*SSMStore, error) {
 		return nil, errors.WithStack(err)
 	}
 	store := &SSMStore{
-		config: config,
-		store:  paramStore,
+		store: paramStore,
 	}
 	return store, nil
 }
@@ -57,7 +55,7 @@ func (s *SSMStore) Set(
 	name string,
 	value string,
 ) error {
-	path := s.config.VarPath(envId, name)
+	path := s.store.config.VarPath(envId, name)
 
 	// New parameter definition
 	tags := buildTags(envId, name)

--- a/envsec/util.go
+++ b/envsec/util.go
@@ -4,25 +4,8 @@
 package envsec
 
 import (
-	"path"
 	"strings"
 )
-
-const PATH_PREFIX = "/jetpack-data/env"
-
-// varPath is the path for a given variable.
-// TODO: Allow customization of this function so that launchpad can use it.
-// Launchpad does projectID/envName/varName.
-func varPath(envId EnvId, varName string) string {
-	return path.Join(pathNamespace(envId), envId.ProjectId, envId.EnvName, varName)
-}
-
-// pathNamespace is the path prefix for all variables for a given organization.
-// TODO: Allow customization of this function so that launchpad can use it.
-// Launchpad uses projectID as prefix.
-func pathNamespace(envId EnvId) string {
-	return path.Join(PATH_PREFIX, envId.OrgId)
-}
 
 func nameFromPath(path string) string {
 	subpaths := strings.Split(path, "/")


### PR DESCRIPTION
## Summary

Allow custom var path and namespace. This can be used by launchpad to co continue backward compatibility.

## How was it tested?
