### PR TITLE
[easy][envsec] Switch to prod endpoint

### DIFF
--- a/envsec/internal/jetcloud/client.go
+++ b/envsec/internal/jetcloud/client.go
@@ -36,7 +36,7 @@ func newClient() *client {
 	return &client{
 		apiHost: envvar.Get(
 			"ENVSEC_API_HOST",
-			"https://envsec-server-web-mike-jetpack-io.cloud.jetpack.dev/",
+			"envsec-server-web-prod.cloud.jetpack.dev/",
 		),
 	}
 }


### PR DESCRIPTION
## Summary

I want to use a custom endpoint but I'm having some issues with launchpad right now so using default endpoint. We can change this after I fix it or after we move the service to google cloud run.

## How was it tested?

`envsec ls`