### PR TITLE
Handle status code errors (easy)

### DIFF
--- a/envsec/internal/jetcloud/client.go
+++ b/envsec/internal/jetcloud/client.go
@@ -91,6 +91,10 @@ func post[T any](ctx context.Context, c *client, user *auth.User, data any) (*T,
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("request failed %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
If we get an error from the HTTP request, we still try to parse it as JSON,. This change checks the status code, and returns an error if the status code was an error
