### PR TITLE
feat(typeid-sql): add support for nullable columns

### DIFF
--- a/typeid/typeid-sql/sql/03_typeid.sql
+++ b/typeid/typeid-sql/sql/03_typeid.sql
@@ -55,6 +55,9 @@ declare
   prefix text;
   suffix text;
 begin
+  if (typeid_str is null) then
+    return null;
+  end if;
   if position('_' in typeid_str) = 0 then
     return ('', base32_decode(typeid_str))::typeid;
   end if;
@@ -82,6 +85,9 @@ declare
   prefix text;
   suffix text;
 begin
+  if (tid is null) then
+    return null;
+  end if;
   prefix = (tid).type;
   suffix = base32_encode((tid).uuid);
   if (prefix is null) or not (prefix ~ '^[a-z]{0,63}$') then


### PR DESCRIPTION
## Summary

This PR adds typeid support for columns with nullable ids.

The SQL standard says:
> Every data type includes a special value, called the null value, sometimes denoted by the keyword NULL.

NULL is a valid value for any data type.

## How was it tested?
```sql
create domain user_id AS typeid check (typeid_check(value, 'user'));
create domain post_id AS typeid check (typeid_check(value, 'post'));

create table users (
    "id" user_id not null default typeid_generate('user')
);

create table posts (
    "id" post_id not null default typeid_generate('post'),
    "user_id" user_id,
    FOREIGN KEY(user_id) REFERENCES "users" (id) ON DELETE SET NULL
);

insert into posts ("user_id") values (null);

select typeid_print(user_id) AS user_id from posts
```