### PR TITLE
[envsec] Improve performance

### DIFF
--- a/.github/workflows/monorepo-go.yml
+++ b/.github/workflows/monorepo-go.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.6.0
+        uses: jetpack-io/devbox-install-action@v0.6.1
 
       - name: Go modules should be up-to-date
         run: |

--- a/.github/workflows/monorepo-go.yml
+++ b/.github/workflows/monorepo-go.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.5.0
+        uses: jetpack-io/devbox-install-action@v0.6.0
 
       - name: Go modules should be up-to-date
         run: |

--- a/envsec/internal/auth/user.go
+++ b/envsec/internal/auth/user.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
+	"go.jetpack.io/envsec/internal/envvar"
 )
 
-const orgIDClaim = "org_id"
+var orgIDClaim = envvar.Get(
+	"ENVSEC_ORG_ID_CLAIM",
+	"org_id",
+)
 
 var ErrNotLoggedIn = errors.New("not logged in")
 

--- a/envsec/internal/awsfed/awsfed.go
+++ b/envsec/internal/awsfed/awsfed.go
@@ -2,11 +2,16 @@ package awsfed
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
 	"github.com/golang-jwt/jwt/v5"
+	"go.jetpack.io/envsec/internal/envvar"
+	"go.jetpack.io/envsec/internal/filecache"
 )
+
+const cacheKey = "awsfed"
 
 type AWSFed struct {
 	AccountId      string
@@ -19,8 +24,11 @@ func New() *AWSFed {
 	return &AWSFed{
 		AccountId:      "984256416385",
 		IdentityPoolId: "us-west-2:8111c156-085b-4ac5-b94d-f823205f6261",
-		Provider:       "accounts.jetpack.io",
-		Region:         "us-west-2",
+		Provider: envvar.Get(
+			"ENVSEC_AUTH_DOMAIN",
+			"accounts.jetpack.io",
+		),
+		Region: "us-west-2",
 	}
 }
 
@@ -28,6 +36,14 @@ func (a *AWSFed) AWSCreds(
 	ctx context.Context,
 	token *jwt.Token,
 ) (*types.Credentials, error) {
+	cache := filecache.New("envsec")
+	if cachedCreds, err := cache.Get(cacheKey); err == nil {
+		var creds types.Credentials
+		if err := json.Unmarshal(cachedCreds, &creds); err == nil {
+			return &creds, nil
+		}
+	}
+
 	svc := cognitoidentity.New(cognitoidentity.Options{
 		Region: a.Region,
 	})
@@ -55,5 +71,16 @@ func (a *AWSFed) AWSCreds(
 	if err != nil {
 		return nil, err
 	}
+
+	if creds, err := json.Marshal(output.Credentials); err != nil {
+		return nil, err
+	} else if err := cache.SetT(
+		cacheKey,
+		creds,
+		*output.Credentials.Expiration,
+	); err != nil {
+		return nil, err
+	}
+
 	return output.Credentials, nil
 }

--- a/envsec/internal/envcli/auth.go
+++ b/envsec/internal/envcli/auth.go
@@ -102,7 +102,7 @@ func newAuthenticator() *auth.Authenticator {
 		),
 		Domain: envvar.Get(
 			"ENVSEC_AUTH_DOMAIN",
-			"accounts.jetpack.io",
+			"auth.jetpack.io",
 		),
 		Scope: envvar.Get(
 			"ENVSEC_AUTH_SCOPE",

--- a/envsec/internal/filecache/filecache.go
+++ b/envsec/internal/filecache/filecache.go
@@ -1,0 +1,74 @@
+// filecache is a simple local file-based cache
+package filecache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.jetpack.io/envsec/internal/xdg"
+)
+
+var NotFound = errors.New("not found")
+var Expired = errors.New("expired")
+
+const prefix = "filecache-"
+
+type cache struct {
+	appName string
+}
+
+func New(appName string) *cache {
+	return &cache{appName: appName}
+}
+
+type data struct {
+	Val []byte
+	Exp time.Time
+}
+
+func (c *cache) Set(key string, val []byte, dur time.Duration) error {
+	d, err := json.Marshal(data{Val: val, Exp: time.Now().Add(dur)})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(os.WriteFile(c.filename(key), d, 0644))
+}
+
+func (c *cache) SetT(key string, val []byte, t time.Time) error {
+	d, err := json.Marshal(data{Val: val, Exp: t})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(os.WriteFile(c.filename(key), d, 0644))
+}
+
+func (c *cache) Get(key string) ([]byte, error) {
+	path := c.filename(key)
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, NotFound
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	d := data{}
+	if err := json.Unmarshal(content, &d); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if time.Now().After(d.Exp) {
+		return nil, Expired
+	}
+	return d.Val, nil
+}
+
+func (c *cache) filename(key string) string {
+	dir := xdg.CacheSubpath(c.appName)
+	_ = os.MkdirAll(dir, 0755)
+	return xdg.CacheSubpath(filepath.Join(c.appName, prefix+key))
+}

--- a/envsec/internal/xdg/xdg.go
+++ b/envsec/internal/xdg/xdg.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Jetpack Technologies Inc and contributors. All rights reserved.
+// Use of this source code is governed by the license in the LICENSE file.
+
+package xdg
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DataSubpath(subpath string) string {
+	return filepath.Join(dataDir(), subpath)
+}
+
+func ConfigSubpath(subpath string) string {
+	return filepath.Join(configDir(), subpath)
+}
+
+func CacheSubpath(subpath string) string {
+	return filepath.Join(cacheDir(), subpath)
+}
+
+func StateSubpath(subpath string) string {
+	return filepath.Join(stateDir(), subpath)
+}
+
+func dataDir() string   { return resolveDir("XDG_DATA_HOME", ".local/share") }
+func configDir() string { return resolveDir("XDG_CONFIG_HOME", ".config") }
+func cacheDir() string  { return resolveDir("XDG_CACHE_HOME", ".cache") }
+func stateDir() string  { return resolveDir("XDG_STATE_HOME", ".local/state") }
+
+func resolveDir(envvar string, defaultPath string) string {
+	dir := os.Getenv(envvar)
+	if dir != "" {
+		return dir
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "~"
+	}
+
+	return filepath.Join(home, defaultPath)
+}

--- a/envsec/ssm_store.go
+++ b/envsec/ssm_store.go
@@ -31,6 +31,9 @@ func newSSMStore(ctx context.Context, config *SSMConfig) (*SSMStore, error) {
 }
 
 func (s *SSMStore) List(ctx context.Context, envId EnvId) ([]EnvVar, error) {
+	if s.store.config.hasDefaultPaths() {
+		return s.store.listByPath(ctx, envId)
+	}
 	return s.store.listByTags(ctx, envId)
 }
 
@@ -55,7 +58,7 @@ func (s *SSMStore) Set(
 	name string,
 	value string,
 ) error {
-	path := s.store.config.VarPath(envId, name)
+	path := s.store.config.varPath(envId, name)
 
 	// New parameter definition
 	tags := buildTags(envId, name)


### PR DESCRIPTION
## Summary

This improves performance by making 2 changes:

* Params are looked up by path instead of by tags. Backwards compatibitlity is perseved by doing tag looking for clients that specify custom paths (e.g. launchpad)
* Cache aws credentials. When the cognito/STS exchange happens we get credentials that are good for 60 minutes. We cache them locally and reuse them if they exist and are not expired.

Total improvement was about 1.7s when credentials are cached (2s -> 300ms)

Other changes:

* Added xdg lib as internal (we can opensource so we can share among projects)
* Added simple filecache lib (launchpad uses a similar version. We could open source this as well)

## How was it tested?

* Used env variables to set auth0 as auth provider
* Benchmarked

When credentials are cached:

* envsec ls is ~500ms
* envsec ls for a single env is 200-300ms

Delta:
* Fetching credentials takes ~1.5s
* Switching from listByTags to listByPath saves 100-200ms 


