### PR TITLE
[envsec] Save orgID and validate project belongs to org

### DIFF
--- a/envsec/internal/typeids/typeids.go
+++ b/envsec/internal/typeids/typeids.go
@@ -1,0 +1,26 @@
+package typeids
+
+import typeid "go.jetpack.io/typeid/typed"
+
+type projectPrefix struct{}
+
+func (projectPrefix) Type() string { return "proj" }
+
+type ProjectID struct{ typeid.TypeID[projectPrefix] }
+
+var NilProjectID = ProjectID{typeid.Nil[projectPrefix]()}
+
+type organizationPrefix struct{}
+
+func (organizationPrefix) Type() string { return "org" }
+
+type OrganizationID struct {
+	typeid.TypeID[organizationPrefix]
+}
+
+var NilOrganizationID = OrganizationID{typeid.Nil[organizationPrefix]()}
+
+func OrganizationIDFromString(s string) (OrganizationID, error) {
+	id, err := typeid.FromString[organizationPrefix](s)
+	return OrganizationID{id}, err
+}


### PR DESCRIPTION
## Summary

* Saves orgID in envsec project config
* Validates that it matches

## How was it tested?

```
envsec int
cat .jetpack/envsec.json # inspected
envsec set FOO=BAR
envsec ls
vi .jetpack/envsec.json # modified with bad org_id
envsec ls 
# got error that the project does not belong to organization
```