### PR TITLE
[envsec] Use legacy token if needed

### DIFF
--- a/envsec/internal/auth/cache.go
+++ b/envsec/internal/auth/cache.go
@@ -21,7 +21,7 @@ func (a *Authenticator) fetchJWKSWithCache() (*keyfunc.JWKS, error) {
 	if err != nil {
 		baseDir = "~/.cache"
 	}
-	// example ~/.cache/jetpack/accounts.jetpack.io.jwks.json
+	// example ~/.cache/jetpack/example.com.jwks.json
 	cacheDir := filepath.Join(baseDir, dirName)
 	path := filepath.Join(cacheDir, fileName)
 

--- a/envsec/internal/auth/user.go
+++ b/envsec/internal/auth/user.go
@@ -17,6 +17,8 @@ var orgIDClaim = envvar.Get(
 	"org_id",
 )
 
+const legacyOrgIDClaim = "https://auth.jetpack.io/org_id"
+
 var ErrNotLoggedIn = errors.New("not logged in")
 var ErrNoOrgID = errors.New("no org ID")
 
@@ -82,6 +84,9 @@ func (u *User) OrgID() (typeids.OrganizationID, error) {
 		return typeids.NilOrganizationID, ErrNotLoggedIn
 	}
 	id, ok := u.AccessToken.Claims.(jwt.MapClaims)[orgIDClaim].(string)
+	if !ok {
+		id, ok = u.AccessToken.Claims.(jwt.MapClaims)[legacyOrgIDClaim].(string)
+	}
 	if !ok {
 		return typeids.NilOrganizationID, ErrNoOrgID
 	}


### PR DESCRIPTION
## Summary

This change allows envsec to work end-to-end using auth0. This is ready for dogfooding with devbox if we want.

## How was it tested?

```
envsec init
envsec set FOO=BAR
envsec ls --show
```