### PR TITLE
[envsec] Add global --json-errors flag

### DIFF
--- a/envsec/cmd/envsec/main.go
+++ b/envsec/cmd/envsec/main.go
@@ -5,10 +5,11 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"go.jetpack.io/envsec/internal/envcli"
 )
 
 func main() {
-	envcli.Execute(context.Background())
+	os.Exit(envcli.Execute(context.Background()))
 }

--- a/envsec/internal/envcli/root.go
+++ b/envsec/internal/envcli/root.go
@@ -5,12 +5,20 @@ package envcli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
 )
 
-func EnvCmd() *cobra.Command {
+type rootCmdFlags struct {
+	jsonErrors bool
+}
+
+func RootCmd(flags *rootCmdFlags) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "envsec",
 		Short: "Manage environment variables and secrets",
@@ -21,12 +29,27 @@ func EnvCmd() *cobra.Command {
 			Environment variables are always encrypted, which makes it possible to
 			store values that contain passwords and other secrets.
 		`),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if flags.jsonErrors {
+				// Don't print anything to stderr so we can print the error in json
+				cmd.SetErr(io.Discard)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 		// we're manually showing usage
 		SilenceUsage: true,
+		// We manually capture errors so we can print different formats
+		SilenceErrors: true,
 	}
+
+	command.PersistentFlags().BoolVar(
+		&flags.jsonErrors,
+		"json-errors", false, "Print errors in json format",
+	)
+	command.Flag("json-errors").Hidden = true
 
 	command.AddCommand(authCmd())
 	command.AddCommand(downloadCmd())
@@ -40,7 +63,27 @@ func EnvCmd() *cobra.Command {
 	return command
 }
 
-func Execute(ctx context.Context) {
-	cmd := EnvCmd()
-	_ = cmd.ExecuteContext(ctx)
+func Execute(ctx context.Context) int {
+	flags := &rootCmdFlags{}
+	cmd := RootCmd(flags)
+	err := cmd.ExecuteContext(ctx)
+	if err == nil {
+		return 0
+	}
+	if flags.jsonErrors {
+		var jsonErr struct {
+			Error string `json:"error"`
+		}
+		jsonErr.Error = err.Error()
+		b, err := json.Marshal(jsonErr)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		} else {
+			fmt.Println(string(b))
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	return 1
+
 }

--- a/envsec/internal/jetcloud/client.go
+++ b/envsec/internal/jetcloud/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 
 	"go.jetpack.io/auth/session"
 	"go.jetpack.io/envsec/internal/envvar"
@@ -38,8 +37,6 @@ func (c *client) endpoint(path string) string {
 }
 
 func (c *client) newProjectID(ctx context.Context, tok *session.Token, repo, subdir string) (typeids.ProjectID, error) {
-	fmt.Fprintf(os.Stderr, "Creating new project for repo=%s subdir=%s\n", repo, subdir)
-
 	p, err := post[struct {
 		ID typeids.ProjectID `json:"id"`
 	}](ctx, c, tok, map[string]string{

--- a/envsec/internal/jetcloud/project.go
+++ b/envsec/internal/jetcloud/project.go
@@ -20,6 +20,9 @@ type projectConfig struct {
 }
 
 func InitProject(ctx context.Context, tok *session.Token, wd string) (typeids.ProjectID, error) {
+	if tok == nil {
+		return typeids.NilProjectID, errors.Errorf("Please login first")
+	}
 	existing, err := ProjectID(wd)
 	if err == nil {
 		return typeids.NilProjectID,


### PR DESCRIPTION
## Summary

This helps devbox understand envsec errors. Added a global error flag instead of individual `--format` flags because it is easier to do and not all commands will have `--format`.

## How was it tested?
`./dist/envsec init --json-errors`