### PR TITLE
[CICD] update devbox github action version

### DIFF
--- a/.github/workflows/monorepo-go.yml
+++ b/.github/workflows/monorepo-go.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.6.1
+        uses: jetpack-io/devbox-install-action@v0.7.0
 
       - name: Go modules should be up-to-date
         run: |


### PR DESCRIPTION
## Summary
Update devbox github action version to v7 for better caching

## How was it tested?
cicd