### PR TITLE
[auth] Set success and failure redirect by flag

### DIFF
--- a/envsec/internal/envcli/auth.go
+++ b/envsec/internal/envcli/auth.go
@@ -133,8 +133,11 @@ func whoAmICmd() *cobra.Command {
 func newAuthClient() (*auth.Client, error) {
 	issuer := envvar.Get("ENVSEC_ISSUER", "https://accounts.jetpack.io")
 	clientID := envvar.Get("ENVSEC_CLIENT_ID", "ff3d4c9c-1ac8-42d9-bef1-f5218bb1a9f6")
+	successURL := envvar.Get("ENVSEC_SUCCESS_URL", "https://www.jetpack.io/account/login/success?product=envsec")
+	failureURL := envvar.Get("ENVSEC_FAILURE_URL", "https://www.jetpack.io/account/login/error?product=envsec")
+
 	// TODO: Consider making scopes and audience configurable:
 	// "ENVSEC_AUTH_SCOPE" = "openid offline_access email profile"
 	// "ENVSEC_AUTH_AUDIENCE" = "https://api.jetpack.io",
-	return auth.NewClient(issuer, clientID)
+	return auth.NewClient(issuer, clientID, successURL, failureURL)
 }

--- a/pkg/sandbox/auth/cmd/auth/cli/login.go
+++ b/pkg/sandbox/auth/cmd/auth/cli/login.go
@@ -14,20 +14,24 @@ import (
 )
 
 type loginFlags struct {
-	client string
+	client  string
+	success string
+	failure string
 }
 
 func LoginCmd() *cobra.Command {
 	flags := &loginFlags{}
 
 	command := &cobra.Command{
-		Use:   "login <issuer> --client <client-id>",
+		Use:   "login <issuer> --client <client-id> --success <url> --failure <url>",
 		Short: "Login using OIDC",
 		Args:  cobra.ExactArgs(1),
 		RunE:  loginCmd(flags),
 	}
 
 	command.Flags().StringVar(&flags.client, "client", "", "client id")
+	command.Flags().StringVar(&flags.success, "success", "https://www.jetpack.io/account/login/success", "URL to display in the browser upon success")
+	command.Flags().StringVar(&flags.failure, "failure", "https://www.jetpack.io/account/login/failure", "URL to display in the browser upon failure")
 
 	return command
 }
@@ -40,12 +44,13 @@ func loginCmd(flags *loginFlags) func(cmd *cobra.Command, args []string) error {
 		if clientID == "" {
 			return fmt.Errorf("please provide a client id")
 		}
-		return login(issuer, clientID)
+
+		return login(issuer, clientID, flags.success, flags.failure)
 	}
 }
 
-func login(issuer, clientID string) error {
-	client, err := auth.NewClient(issuer, clientID)
+func login(issuer, clientID, success, failure string) error {
+	client, err := auth.NewClient(issuer, clientID, success, failure)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Set success and failure redirect by flag. Default to the jetpack urls

## How was it tested?
```
go build -o dist/auth cmd/auth/main.go
./dist/auth login https://accounts.jetpack.io --client <client-id> --success https://www.jetpack.io/account/login/success?product=envsec
```