### PR TITLE
[envsec] Bump pkg version to ensure auth location is correct

### DIFF
--- a/envsec/go.mod
+++ b/envsec/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.38.1
 	github.com/spf13/cobra v1.7.0
-	go.jetpack.io/pkg v0.0.0-20230915205515-567047de7b30
+	go.jetpack.io/pkg v0.0.0-20230920232528-54278537129b
 	go.jetpack.io/typeid v0.1.0
 	golang.org/x/oauth2 v0.12.0
 	golang.org/x/text v0.13.0

--- a/envsec/go.sum
+++ b/envsec/go.sum
@@ -109,8 +109,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-go.jetpack.io/pkg v0.0.0-20230915205515-567047de7b30 h1:s/UMwh3iqQk792t4AhZZtPX0PagGTKwOylOs0cl1gMo=
-go.jetpack.io/pkg v0.0.0-20230915205515-567047de7b30/go.mod h1:6RVzBortLFlql8s8oKJTX2+H7DDzp8Lr7wiIOI3FauU=
+go.jetpack.io/pkg v0.0.0-20230920232528-54278537129b h1:8sbFeLQ7GtVP7CxvpmBoOh6w2ZTK4DyZuMkyiIGFdjs=
+go.jetpack.io/pkg v0.0.0-20230920232528-54278537129b/go.mod h1:drBQ4v8Hxs501Y3KK3vbsNBhn/TEMEDHrdXK7cOb9yg=
 go.jetpack.io/typeid v0.1.0 h1:suTmjNR3y2em2gCTG06agFfcACm3+zuxfziMUk5UXnw=
 go.jetpack.io/typeid v0.1.0/go.mod h1:E11ObFkKlvsSTxwwYIm+zpbsRthjIMDy/JGBogs2vSo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Summary

This is an unfortunate needed step. When we make changes in pkg, downstream dependencies don't get the newest pkg. This means we need 2 commits. We could automate this, but it would still require an additional commit.

## How was it tested?

builds