### PR TITLE
[envsec] Better error messages when no valid token

### DIFF
--- a/envsec/internal/envcli/auth.go
+++ b/envsec/internal/envcli/auth.go
@@ -6,6 +6,7 @@ package envcli
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec/internal/envvar"
 	"go.jetpack.io/pkg/sandbox/auth"
@@ -101,10 +102,9 @@ func whoAmICmd() *cobra.Command {
 				return err
 			}
 
-			tok := client.GetSession()
-			if tok == nil {
-				fmt.Fprintln(cmd.OutOrStdout(), "Not logged in")
-				return nil
+			tok, ok := client.GetSession()
+			if !ok {
+				return errors.New("Not logged in. Run `envsec auth login` to log in.")
 			}
 			idClaims := tok.IDClaims()
 

--- a/envsec/internal/envcli/flags.go
+++ b/envsec/internal/envcli/flags.go
@@ -81,6 +81,7 @@ type cmdConfig struct {
 
 func (f *configFlags) genConfig(ctx context.Context) (*cmdConfig, error) {
 	var tok *session.Token
+	var ok bool
 	var err error
 
 	if f.orgID == "" {
@@ -89,8 +90,8 @@ func (f *configFlags) genConfig(ctx context.Context) (*cmdConfig, error) {
 			return nil, err
 		}
 
-		tok = client.GetSession()
-		if tok == nil {
+		tok, ok = client.GetSession()
+		if !ok {
 			return nil, errors.Errorf(
 				"To use envsec you must log in (`envsec auth login`) or specify --project-id and --org-id",
 			)

--- a/envsec/internal/envcli/init.go
+++ b/envsec/internal/envcli/init.go
@@ -19,7 +19,10 @@ func initCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tok := client.GetSession()
+			tok, ok := client.GetSession()
+			if !ok {
+				return errors.New("not logged in, run `envsec auth login`")
+			}
 
 			wd, err := os.Getwd()
 			if err != nil {


### PR DESCRIPTION
## Summary

Stacked on https://github.com/jetpack-io/opensource/pull/158

This uses new GetSession interface to show better errors when ID token doesn't exist, is expired, or otherwise invalid.

## How was it tested?

```
envsec auth logout
envsec init
```
