### PR TITLE
[envsec] Ensure id token is refreshed

### DIFF
--- a/envsec/internal/envcli/auth.go
+++ b/envsec/internal/envcli/auth.go
@@ -19,7 +19,6 @@ func authCmd() *cobra.Command {
 
 	cmd.AddCommand(loginCmd())
 	cmd.AddCommand(logoutCmd())
-	cmd.AddCommand(refreshCmd())
 	cmd.AddCommand(whoAmICmd())
 
 	return cmd
@@ -63,34 +62,6 @@ func logoutCmd() *cobra.Command {
 				fmt.Fprintln(cmd.OutOrStdout(), "Logged out successfully")
 			}
 			return err
-		},
-	}
-
-	return cmd
-}
-
-// This is for debugging purposes only. Hidden.
-func refreshCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:    "refresh",
-		Short:  "Refresh credentials",
-		Args:   cobra.ExactArgs(0),
-		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := newAuthClient()
-			if err != nil {
-				return err
-			}
-
-			_, err = client.GetSession(cmd.Context())
-			if err != nil {
-				return fmt.Errorf(
-					"failed to refresh: %w. Run `envsec auth login` to log in",
-					err,
-				)
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), "Refreshed successfully")
-			return nil
 		},
 	}
 

--- a/envsec/internal/envcli/auth.go
+++ b/envsec/internal/envcli/auth.go
@@ -6,7 +6,6 @@ package envcli
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec/internal/envvar"
 	"go.jetpack.io/pkg/sandbox/auth"
@@ -83,9 +82,12 @@ func refreshCmd() *cobra.Command {
 				return err
 			}
 
-			_, ok := client.GetSession(cmd.Context())
-			if !ok {
-				return errors.New("Failed to refresh: not logged in. Run `envsec auth login` to log in")
+			_, err = client.GetSession(cmd.Context())
+			if err != nil {
+				return fmt.Errorf(
+					"failed to refresh: %w. Run `envsec auth login` to log in",
+					err,
+				)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Refreshed successfully")
 			return nil
@@ -111,9 +113,9 @@ func whoAmICmd() *cobra.Command {
 				return err
 			}
 
-			tok, ok := client.GetSession(cmd.Context())
-			if !ok {
-				return errors.New("not logged in. Run `envsec auth login` to log in")
+			tok, err := client.GetSession(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("error: %w. Run `envsec auth login` to log in", err)
 			}
 			idClaims := tok.IDClaims()
 
@@ -136,7 +138,6 @@ func whoAmICmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "Access Token: %s\n", tok.AccessToken)
 				fmt.Fprintf(cmd.OutOrStdout(), "ID Token: %s\n", tok.IDToken)
 				fmt.Fprintf(cmd.OutOrStdout(), "Refresh Token: %s\n", tok.RefreshToken)
-
 			}
 
 			return nil

--- a/envsec/internal/envcli/flags.go
+++ b/envsec/internal/envcli/flags.go
@@ -5,6 +5,7 @@ package envcli
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -56,8 +57,8 @@ func (f *configFlags) validateProjectID(orgID typeids.OrganizationID) (string, e
 	}
 	config, err := jetcloud.ProjectConfig(wd)
 	if errors.Is(err, os.ErrNotExist) {
-		return "", errors.Errorf(
-			"Project ID not specified. You must run `envsec init` or specify --project-id in this directory",
+		return "", fmt.Errorf(
+			"project ID not specified. You must run `envsec init` or specify --project-id in this directory",
 		)
 	} else if err != nil {
 		return "", errors.WithStack(err)
@@ -81,7 +82,6 @@ type cmdConfig struct {
 
 func (f *configFlags) genConfig(ctx context.Context) (*cmdConfig, error) {
 	var tok *session.Token
-	var ok bool
 	var err error
 
 	if f.orgID == "" {
@@ -90,10 +90,11 @@ func (f *configFlags) genConfig(ctx context.Context) (*cmdConfig, error) {
 			return nil, err
 		}
 
-		tok, ok = client.GetSession(ctx)
-		if !ok {
-			return nil, errors.Errorf(
-				"To use envsec you must log in (`envsec auth login`) or specify --project-id and --org-id",
+		tok, err = client.GetSession(ctx)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"error: %w. To use envsec you must log in (`envsec auth login`) or specify --project-id and --org-id",
+				err,
 			)
 		}
 	}

--- a/envsec/internal/envcli/init.go
+++ b/envsec/internal/envcli/init.go
@@ -19,9 +19,9 @@ func initCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			tok, ok := client.GetSession(cmd.Context())
-			if !ok {
-				return errors.New("not logged in, run `envsec auth login`")
+			tok, err := client.GetSession(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("error: %w, run `envsec auth login`", err)
 			}
 
 			wd, err := os.Getwd()

--- a/pkg/sandbox/auth/auth.go
+++ b/pkg/sandbox/auth/auth.go
@@ -87,10 +87,6 @@ func (c *Client) refresh(
 	ctx context.Context,
 	tok *session.Token,
 ) (*session.Token, error) {
-	if tok == nil {
-		return nil, ErrNotLoggedIn
-	}
-
 	// TODO: figure out how to share oidc provider and oauth2 client
 	// with auth flow:
 	provider, err := oidc.NewProvider(ctx, c.issuer)

--- a/pkg/sandbox/auth/internal/tokenstore/tokenstore.go
+++ b/pkg/sandbox/auth/internal/tokenstore/tokenstore.go
@@ -23,14 +23,14 @@ func New(rootDir string) (*Store, error) {
 	}, nil
 }
 
-func (s *Store) ReadToken(issuer string, clientID string) *session.Token {
+func (s *Store) ReadToken(issuer string, clientID string) (*session.Token, error) {
 	var tok session.Token
 	path := s.path(issuer, clientID)
 	err := readJSONFile(path, &tok)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return &tok
+	return &tok, nil
 }
 
 func (s *Store) WriteToken(issuer string, clientID string, tok *session.Token) error {


### PR DESCRIPTION
## Summary

* Ensure refresh updates id token, previously it was only updating access token.
* Changed GetSession and a few internal functions to return errors instead of just swallowing it up. 

## How was it tested?

```
envsec auth logout
envsec auth whoami
envsec auth login
envsec auth whoami
envsec auth refresh
# inspected id token to ensure it was refreshed
```
