### PR TITLE
[runx] Allow non-archived binaries

### DIFF
--- a/pkg/sandbox/runx/impl/registry/artifact.go
+++ b/pkg/sandbox/runx/impl/registry/artifact.go
@@ -9,16 +9,21 @@ import (
 )
 
 func findArtifactForPlatform(artifacts []types.ArtifactMetadata, platform types.Platform) *types.ArtifactMetadata {
+	var artifactForPlatform types.ArtifactMetadata
 	for _, artifact := range artifacts {
-		if isArtifactForPlatform(artifact, platform) && isKnownArchive(artifact.Name) {
-			// We only consider known artchives because sometimes releases contain multiple files
-			// for the same platform. Some times those files are alternative installation methods
-			// like `.dmg`, `.msi`, or `.deb`, and sometimes they are metadata files like `.sha256`
-			// or a `.sig` file. We don't want to install those.
-			return &artifact
+		if isArtifactForPlatform(artifact, platform) {
+			artifactForPlatform = artifact
+			if isKnownArchive(artifact.Name) {
+				// We only consider known archives because sometimes releases contain multiple files
+				// for the same platform. Some times those files are alternative installation methods
+				// like `.dmg`, `.msi`, or `.deb`, and sometimes they are metadata files like `.sha256`
+				// or a `.sig` file. We don't want to install those.
+				return &artifact
+			}
 		}
 	}
-	return nil
+	// Best attempt:
+	return &artifactForPlatform
 }
 
 func isArtifactForPlatform(artifact types.ArtifactMetadata, platform types.Platform) bool {

--- a/pkg/sandbox/runx/impl/registry/extract.go
+++ b/pkg/sandbox/runx/impl/registry/extract.go
@@ -56,8 +56,8 @@ func contentDir(path string) string {
 	return filepath.Join(path, contents[0].Name())
 }
 
-func createSymbolicLink(src, dest, repoName string) error {
-	if err := fileutil.EnsureDir(dest); err != nil {
+func createSymbolicLink(src, dst, repoName string) error {
+	if err := os.MkdirAll(dst, 0700); err != nil {
 		return err
 	}
 	if err := os.Chmod(src, 0755); err != nil {
@@ -69,8 +69,9 @@ func createSymbolicLink(src, dest, repoName string) error {
 	if strings.Contains(binaryName, repoName) {
 		binaryName = repoName
 	}
-	err := os.Symlink(src, filepath.Join(dest, binaryName))
+	err := os.Symlink(src, filepath.Join(dst, binaryName))
 	if errors.Is(err, os.ErrExist) {
+		// TODO: verify symlink points to the right place
 		return nil
 	}
 	return err

--- a/pkg/sandbox/runx/impl/registry/extract.go
+++ b/pkg/sandbox/runx/impl/registry/extract.go
@@ -2,8 +2,10 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/codeclysm/extract"
 	"go.jetpack.io/pkg/sandbox/runx/impl/fileutil"
@@ -52,4 +54,24 @@ func contentDir(path string) string {
 		return path
 	}
 	return filepath.Join(path, contents[0].Name())
+}
+
+func createSymbolicLink(src, dest, repoName string) error {
+	if err := fileutil.EnsureDir(dest); err != nil {
+		return err
+	}
+	if err := os.Chmod(src, 0755); err != nil {
+		return err
+	}
+	binaryName := filepath.Base(src)
+	// This is a good guess for the binary name. In the future we could allow
+	// user to customize.
+	if strings.Contains(binaryName, repoName) {
+		binaryName = repoName
+	}
+	err := os.Symlink(src, filepath.Join(dest, binaryName))
+	if errors.Is(err, os.ErrExist) {
+		return nil
+	}
+	return err
 }

--- a/pkg/sandbox/runx/impl/registry/registry.go
+++ b/pkg/sandbox/runx/impl/registry/registry.go
@@ -121,7 +121,7 @@ func (r *Registry) GetPackage(ctx context.Context, ref types.PkgRef, platform ty
 
 	if isKnownArchive(filepath.Base(artifactPath)) {
 		err = Extract(ctx, artifactPath, installPath.String())
-	} else if isBinary(artifactPath) {
+	} else if isExecutableBinary(artifactPath) {
 		err = createSymbolicLink(artifactPath, installPath.String(), resolvedRef.Repo)
 	}
 	if err != nil {
@@ -166,7 +166,8 @@ func (r *Registry) ResolveVersion(ref types.PkgRef) (types.PkgRef, error) {
 	}, nil
 }
 
-func isBinary(path string) bool {
+// Best effort heuristic to determine if the artifact is an executable binary.
+func isExecutableBinary(path string) bool {
 	file, err := os.Open(path)
 	if err != nil {
 		return false

--- a/pkg/sandbox/runx/impl/registry/registry.go
+++ b/pkg/sandbox/runx/impl/registry/registry.go
@@ -118,7 +118,12 @@ func (r *Registry) GetPackage(ctx context.Context, ref types.PkgRef, platform ty
 		return "", err
 	}
 
-	err = Extract(ctx, artifactPath, installPath.String())
+	if isKnownArchive(filepath.Base(artifactPath)) {
+		err = Extract(ctx, artifactPath, installPath.String())
+	} else {
+		// If we can't extract, treat as binary
+		err = createSymbolicLink(artifactPath, installPath.String(), resolvedRef.Repo)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sandbox/runx/impl/registry/registry_test.go
+++ b/pkg/sandbox/runx/impl/registry/registry_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsBinary(t *testing.T) {
+	tests := []struct {
+		name   string
+		header []byte
+		want   bool
+	}{
+		{"Shebang", []byte("#!/bin/bash\n"), true},
+		{"ELF", []byte{0x7f, 0x45, 0x4c, 0x46}, true},
+		{"MachO32 BE", []byte{0xfe, 0xed, 0xfa, 0xce}, true},
+		{"MachO64 BE", []byte{0xfe, 0xed, 0xfa, 0xcf}, true},
+		{"Java Class", []byte{0xca, 0xfe, 0xba, 0xbe}, true},
+		{"MachO64 LE", []byte{0xcf, 0xfa, 0xed, 0xfe}, true},
+		{"MachO32 LE", []byte{0xce, 0xfa, 0xed, 0xfe}, true},
+		{"Unknown", []byte{0xaa, 0xbb, 0xcc, 0xdd}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := os.CreateTemp("", "testfile")
+			if err != nil {
+				t.Fatalf("Could not create temp file: %v", err)
+			}
+			defer os.Remove(file.Name())
+
+			_, err = file.Write(test.header)
+			if err != nil {
+				t.Fatalf("Could not write to temp file: %v", err)
+			}
+			file.Close()
+
+			got := isBinary(file.Name())
+			if got != test.want {
+				t.Errorf("isBinary() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/sandbox/runx/impl/registry/registry_test.go
+++ b/pkg/sandbox/runx/impl/registry/registry_test.go
@@ -35,7 +35,7 @@ func TestIsBinary(t *testing.T) {
 			}
 			file.Close()
 
-			got := isBinary(file.Name())
+			got := isExecutableBinary(file.Name())
 			if got != test.want {
 				t.Errorf("isBinary() = %v, want %v", got, test.want)
 			}


### PR DESCRIPTION
## Summary

Some repos (e.g. https://github.com/mvdan/gofumpt) release files as binaries instead of archives. This expands runx to treat unknown files (that still match the platform and architecture name structure) as binaries. It only does so if it finds a compatible artifact but the type is unknown.

We could additionally test the mime type of the file, but it doesn't seem like binaries use consistent mime types.

## How was it tested?

`./dist/runx +mvdan/gofumpt gofumpt --help`
