### PR TITLE
[envsec] Changes to allow launchpad to update

### DIFF
--- a/envsec/pkg/envcli/download.go
+++ b/envsec/pkg/envcli/download.go
@@ -35,7 +35,7 @@ func DownloadCmd() *cobra.Command {
 			return errors.Wrapf(errUnsupportedFormat, "format: %s", flags.format)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/envsec/pkg/envcli/exec.go
+++ b/envsec/pkg/envcli/exec.go
@@ -26,23 +26,17 @@ func ExecCmd() *cobra.Command {
 		Long:  "Execute a specified command with remote environment variables being present for the duration of the command. If an environment variable exists both locally and in remote storage, the remotely stored one is prioritized.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return err
 			}
 			commandString := strings.Join(args, " ")
 			commandToRun := exec.Command("/bin/sh", "-c", commandString)
 
-			// Default environment to fetch values from is DEV
-			envNames := []string{"dev"}
-			// If a specific environment was set by the user, then just use that one.
-			if cmd.Flags().Changed(environmentFlagName) {
-				envNames = []string{strings.ToLower(cmdCfg.EnvID.EnvName)}
-			}
 			envID := envsec.EnvID{
 				OrgID:     cmdCfg.EnvID.OrgID,
 				ProjectID: cmdCfg.EnvID.ProjectID,
-				EnvName:   envNames[0],
+				EnvName:   cmdCfg.EnvID.EnvName,
 			}
 			// Get list of stored env variables
 			envVars, err := cmdCfg.Store.List(cmd.Context(), envID)

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -4,7 +4,6 @@
 package envcli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -76,15 +75,17 @@ func (f *configFlags) validateProjectID(orgID typeids.OrganizationID) (string, e
 }
 
 type CmdConfig struct {
-	Store envsec.Store
-	EnvID envsec.EnvID
+	Store    envsec.Store
+	EnvID    envsec.EnvID
+	EnvNames []string
 }
 
-func (f *configFlags) genConfig(ctx context.Context) (*CmdConfig, error) {
+func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 	if bootstrappedConfig != nil {
 		return bootstrappedConfig, nil
 	}
 
+	ctx := cmd.Context()
 	var tok *session.Token
 	var err error
 
@@ -132,9 +133,15 @@ func (f *configFlags) genConfig(ctx context.Context) (*CmdConfig, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	envNames := []string{"dev", "prod", "staging"}
+	if cmd.Flags().Changed(environmentFlagName) {
+		envNames = []string{envid.EnvName}
+	}
+
 	return &CmdConfig{
-		Store: store,
-		EnvID: envid,
+		Store:    store,
+		EnvID:    envid,
+		EnvNames: envNames,
 	}, nil
 }
 

--- a/envsec/pkg/envcli/ls.go
+++ b/envsec/pkg/envcli/ls.go
@@ -4,8 +4,6 @@
 package envcli
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec"
@@ -29,23 +27,17 @@ func ListCmd() *cobra.Command {
 		Long:    "List all stored environment variables. If no environment flag is provided, variables in all environments will be listed.",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return err
 			}
-			// Populate the valid Environments
-			envNames := []string{"dev", "prod", "staging"}
-			// If a specific environment was set by the user, then just use that one.
-			if cmd.Flags().Changed(environmentFlagName) {
-				envNames = []string{strings.ToLower(cmdCfg.EnvID.EnvName)}
-			}
 
 			// TODO: parallelize
-			for _, envName := range envNames {
+			for _, envName := range cmdCfg.EnvNames {
 				envID := envsec.EnvID{
 					OrgID:     cmdCfg.EnvID.OrgID,
 					ProjectID: cmdCfg.EnvID.ProjectID,
-					EnvName:   strings.ToLower(envName),
+					EnvName:   envName,
 				}
 				envVars, err := cmdCfg.Store.List(cmd.Context(), envID)
 				if err != nil {

--- a/envsec/pkg/envcli/rm.go
+++ b/envsec/pkg/envcli/rm.go
@@ -24,7 +24,7 @@ func RemoveCmd() *cobra.Command {
 		Long:  "Delete one or more environment variables that are stored.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, envNames []string) error {
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/envsec/pkg/envcli/set.go
+++ b/envsec/pkg/envcli/set.go
@@ -42,7 +42,7 @@ func SetCmd() *cobra.Command {
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/envsec/pkg/envcli/upload.go
+++ b/envsec/pkg/envcli/upload.go
@@ -74,7 +74,7 @@ func UploadCmd() *cobra.Command {
 				}
 			}
 
-			cmdCfg, err := flags.genConfig(cmd.Context())
+			cmdCfg, err := flags.genConfig(cmd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

For launchpad to update we need:

* Allow bootsrapping of a specific envID
* Don't check if flag has changed in the commands themselves.
* Remove `ToLower` Introduced in https://github.com/jetpack-io/opensource/pull/118. This means envsec will be case sensitive. Note that the comments in that PR are not strictly correct, most commands do not do `ToLower` on environment, only `ls` and `exec` did. 

## How was it tested?

Compiled launchpad with updated version of envsec and tested envsec commands (set, ls, exec, rm)
