### PR TITLE
[envsec] Show good error message when we fail to get access token

### DIFF
--- a/envsec/pkg/envcli/auth.go
+++ b/envsec/pkg/envcli/auth.go
@@ -158,6 +158,7 @@ func getShortTermAccessToken(
 		// token store, but that means our existing refresh token would no longer
 		// be valid because it is only usable once.
 		tok.Expiry = time.Now()
+		tok.AccessToken = ""
 	} else {
 		tok.AccessToken = accessToken
 	}

--- a/envsec/pkg/envcli/auth.go
+++ b/envsec/pkg/envcli/auth.go
@@ -6,6 +6,7 @@ package envcli
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec/internal/envvar"
@@ -148,8 +149,17 @@ func getShortTermAccessToken(
 ) (*session.Token, error) {
 	accessToken, err := jetcloud.GetAccessToken(ctx, tok)
 	if err != nil {
-		return nil, err
+		fmt.Println(err)
+		// We set the current set of tokens to be expired immediately.
+		// This is a hack to force a refresh. Even though we have a new id token,
+		// we failed to get a valid access token. This is likely because the
+		// user doesn't have a valid plan.
+		// Returning a nil token would prevent any new data from being written to
+		// token store, but that means our existing refresh token would no longer
+		// be valid because it is only usable once.
+		tok.Expiry = time.Now()
+	} else {
+		tok.AccessToken = accessToken
 	}
-	tok.AccessToken = accessToken
 	return tok, nil
 }


### PR DESCRIPTION
## Summary

This change does the following:

* Show better error message if the server returns one. In particular, the server will return instructions with a link to user can activate plan.
* If we fail to get an access token from our STS service, still write id token and refresh toke to store but make it expired. This will ensure we have a valid refresh token and that the next time the user tries to use envsec (presumably after clicking on link and selecting a plan) it will refetch all tokens.

## How was it tested?

`ENVSEC_API_HOST=http://localhost:8080 ./dist/envsec auth whoami`
