### PR TITLE
[typeid-go][RFC] Use struct with tags

### DIFF
--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -33,22 +33,6 @@ func New[T TypePrefix]() (TypeID[T], error) {
 	return (TypeID[T])(tid), nil
 }
 
-// New2 creates a new ID which is same type as the struct passed in as the type
-// param. The purpose of untyped.Unimplementable[untyped.TypeID] is to limit
-// to only structs that embed untyped.TypeID.
-// untyped.Copier is only implemented by *untyped.TypeID but we don't want the
-// interface of this function to be `typeid.New2[*OrgID]()` which is ugly
-func New2[T untyped.Unimplementable[untyped.TypeID]]() (T, error) {
-	var newID T
-	tid, err := untyped.New(typeFromTag(newID))
-	if err != nil {
-		return newID, err
-	}
-	var newID2 any = &newID
-	newID2.(untyped.Copier).CopyFrom(tid)
-	return newID, nil
-}
-
 func Type[T TypePrefix]() string {
 	var prefix T
 	return typeOf(prefix)

--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -33,14 +33,19 @@ func New[T TypePrefix]() (TypeID[T], error) {
 	return (TypeID[T])(tid), nil
 }
 
-func New2[T untyped.Unimplementable]() (T, error) {
+// New2 creates a new ID which is same type as the struct passed in as the type
+// param. The purpose of untyped.Unimplementable[untyped.TypeID] is to limit
+// to only structs that embed untyped.TypeID.
+// untyped.Copier is only implemented by *untyped.TypeID but we don't want the
+// interface of this function to be `typeid.New2[*OrgID]()` which is ugly
+func New2[T untyped.Unimplementable[untyped.TypeID]]() (T, error) {
 	var newID T
 	tid, err := untyped.New(typeFromTag(newID))
 	if err != nil {
 		return newID, err
 	}
 	var newID2 any = &newID
-	newID2.(interface{ CopyFrom(untyped.TypeID) }).CopyFrom(tid)
+	newID2.(untyped.Copier).CopyFrom(tid)
 	return newID, nil
 }
 

--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -2,6 +2,7 @@ package typed
 
 import (
 	"fmt"
+	"reflect"
 
 	untyped "go.jetpack.io/typeid"
 )
@@ -34,7 +35,7 @@ func New[T TypePrefix]() (TypeID[T], error) {
 
 func Type[T TypePrefix]() string {
 	var prefix T
-	return prefix.Type()
+	return typeOf(prefix)
 }
 
 // Nil returns the null typeid of the given type.
@@ -45,7 +46,7 @@ func Nil[T TypePrefix]() TypeID[T] {
 // Type returns the type prefix of the TypeID
 func (tid TypeID[T]) Type() string {
 	var prefix T
-	return prefix.Type()
+	return typeOf(prefix)
 }
 
 // Suffix returns the suffix of the TypeID in it's canonical base32 representation.
@@ -86,8 +87,8 @@ func FromString[T TypePrefix](s string) (TypeID[T], error) {
 	if err != nil {
 		return Nil[T](), err
 	}
-	if tid.Type() != Type[T]() {
-		return Nil[T](), fmt.Errorf("invalid type, expected %s but got %s", Type[T](), tid.Type())
+	if typeOf(tid) != Type[T]() {
+		return Nil[T](), fmt.Errorf("invalid type, expected %s but got %s", Type[T](), typeOf(tid))
 	}
 	return (TypeID[T])(tid), nil
 }
@@ -116,4 +117,24 @@ func Must[T TypePrefix](tid TypeID[T], err error) TypeID[T] {
 		panic(err)
 	}
 	return tid
+}
+
+var prefixMap = map[reflect.Type]string{}
+
+func typeOf(tp TypePrefix) string {
+	if tp.Type() != "" {
+		return tp.Type()
+	}
+	t := reflect.TypeOf(tp)
+	if prefix, ok := prefixMap[t]; ok {
+		return prefix
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).Name == "TypeID" {
+			prefixMap[t] = t.Field(i).Tag.Get("prefix")
+			return t.Field(i).Tag.Get("prefix")
+		}
+	}
+	return ""
 }

--- a/typeid/typeid-go/typed/typed.go
+++ b/typeid/typeid-go/typed/typed.go
@@ -33,6 +33,17 @@ func New[T TypePrefix]() (TypeID[T], error) {
 	return (TypeID[T])(tid), nil
 }
 
+func New2[T untyped.Unimplementable]() (T, error) {
+	var newID T
+	tid, err := untyped.New(typeFromTag(newID))
+	if err != nil {
+		return newID, err
+	}
+	var newID2 any = &newID
+	newID2.(interface{ CopyFrom(untyped.TypeID) }).CopyFrom(tid)
+	return newID, nil
+}
+
 func Type[T TypePrefix]() string {
 	var prefix T
 	return typeOf(prefix)
@@ -125,6 +136,12 @@ func typeOf(tp TypePrefix) string {
 	if tp.Type() != "" {
 		return tp.Type()
 	}
+	return typeFromTag(tp)
+}
+
+// tp could be a untyped.TypeID type, but I don't want to check type inside
+// the typeOf function.
+func typeFromTag(tp any) string {
 	t := reflect.TypeOf(tp)
 	if prefix, ok := prefixMap[t]; ok {
 		return prefix

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -28,7 +28,7 @@ func Example() {
 	userID, _ := typeid.New[UserID]()
 	accountID, _ := typeid.New[AccountID]()
 	orgID, _ := typeid.New[OrgID]()
-	orgID2, _ := typeid.New2[OrgID]()
+	orgID2, _ := untyped.New2[OrgID]()
 	// Each ID should have the correct type prefix:
 	fmt.Printf("User ID prefix: %s\n", userID.Type())
 	fmt.Printf("Account ID prefix: %s\n", accountID.Type())
@@ -53,7 +53,7 @@ func Example() {
 
 	start = time.Now()
 	for i := 0; i < 1000000; i++ {
-		id, _ := typeid.New2[OrgID]()
+		id, _ := untyped.New2[OrgID]()
 		_ = id.Type()
 	}
 	fmt.Printf("1000000 New2[OrgID] calls took %v\n", time.Since(start))

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -2,7 +2,9 @@ package typed_test
 
 import (
 	"fmt"
+	"time"
 
+	untypeid "go.jetpack.io/typeid"
 	typeid "go.jetpack.io/typeid/typed"
 )
 
@@ -18,14 +20,34 @@ func (accountPrefix) Type() string { return "account" }
 
 type AccountID struct{ typeid.TypeID[accountPrefix] }
 
+type OrgID struct {
+	untypeid.TypeID `prefix:"org"`
+}
+
 func Example() {
 	userID, _ := typeid.New[UserID]()
 	accountID, _ := typeid.New[AccountID]()
+	orgID, _ := typeid.New[OrgID]()
 	// Each ID should have the correct type prefix:
 	fmt.Printf("User ID prefix: %s\n", userID.Type())
 	fmt.Printf("Account ID prefix: %s\n", accountID.Type())
+	fmt.Printf("Org ID prefix: %s\n", orgID.Type())
 	// The compiler considers their go types to be different:
 	fmt.Printf("%T != %T\n", userID, accountID)
+
+	start := time.Now()
+	for i := 0; i < 1000000; i++ {
+		id, _ := typeid.New[UserID]()
+		id.Type()
+	}
+	fmt.Printf("1000000 New[UserID] calls took %v\n", time.Since(start))
+
+	start = time.Now()
+	for i := 0; i < 1000000; i++ {
+		id, _ := typeid.New[OrgID]()
+		id.Type()
+	}
+	fmt.Printf("1000000 New[OrgID] calls took %v\n", time.Since(start))
 
 	// Output:
 	// User ID prefix: user

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -27,12 +27,10 @@ type OrgID struct {
 func Example() {
 	userID, _ := typeid.New[UserID]()
 	accountID, _ := typeid.New[AccountID]()
-	orgID, _ := typeid.New[OrgID]()
 	orgID2, _ := untyped.New2[OrgID]()
 	// Each ID should have the correct type prefix:
 	fmt.Printf("User ID prefix: %s\n", userID.Type())
 	fmt.Printf("Account ID prefix: %s\n", accountID.Type())
-	fmt.Printf("Org ID prefix: %s\n", orgID.Type())
 	fmt.Printf("Org2 ID prefix: %s\n", orgID2.Type())
 	// The compiler considers their go types to be different:
 	fmt.Printf("%T != %T\n", userID, accountID)
@@ -43,13 +41,6 @@ func Example() {
 		_ = id.Type()
 	}
 	fmt.Printf("1000000 New[UserID] calls took %v\n", time.Since(start))
-
-	start = time.Now()
-	for i := 0; i < 1000000; i++ {
-		id, _ := typeid.New[OrgID]()
-		_ = id.Type()
-	}
-	fmt.Printf("1000000 New[OrgID] calls took %v\n", time.Since(start))
 
 	start = time.Now()
 	for i := 0; i < 1000000; i++ {

--- a/typeid/typeid-go/typed/typed_example_test.go
+++ b/typeid/typeid-go/typed/typed_example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	untypeid "go.jetpack.io/typeid"
+	untyped "go.jetpack.io/typeid"
 	typeid "go.jetpack.io/typeid/typed"
 )
 
@@ -21,33 +21,42 @@ func (accountPrefix) Type() string { return "account" }
 type AccountID struct{ typeid.TypeID[accountPrefix] }
 
 type OrgID struct {
-	untypeid.TypeID `prefix:"org"`
+	untyped.TypeID `prefix:"org"`
 }
 
 func Example() {
 	userID, _ := typeid.New[UserID]()
 	accountID, _ := typeid.New[AccountID]()
 	orgID, _ := typeid.New[OrgID]()
+	orgID2, _ := typeid.New2[OrgID]()
 	// Each ID should have the correct type prefix:
 	fmt.Printf("User ID prefix: %s\n", userID.Type())
 	fmt.Printf("Account ID prefix: %s\n", accountID.Type())
 	fmt.Printf("Org ID prefix: %s\n", orgID.Type())
+	fmt.Printf("Org2 ID prefix: %s\n", orgID2.Type())
 	// The compiler considers their go types to be different:
 	fmt.Printf("%T != %T\n", userID, accountID)
 
 	start := time.Now()
 	for i := 0; i < 1000000; i++ {
 		id, _ := typeid.New[UserID]()
-		id.Type()
+		_ = id.Type()
 	}
 	fmt.Printf("1000000 New[UserID] calls took %v\n", time.Since(start))
 
 	start = time.Now()
 	for i := 0; i < 1000000; i++ {
 		id, _ := typeid.New[OrgID]()
-		id.Type()
+		_ = id.Type()
 	}
 	fmt.Printf("1000000 New[OrgID] calls took %v\n", time.Since(start))
+
+	start = time.Now()
+	for i := 0; i < 1000000; i++ {
+		id, _ := typeid.New2[OrgID]()
+		_ = id.Type()
+	}
+	fmt.Printf("1000000 New2[OrgID] calls took %v\n", time.Since(start))
 
 	// Output:
 	// User ID prefix: user

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -67,7 +67,7 @@ func (tid TypeID) UUID() string {
 	return uuid.FromBytesOrNil(tid.UUIDBytes()).String()
 }
 
-func (tid *TypeID) CopyFrom(other TypeID) {
+func (tid *TypeID) copyFrom(other TypeID) {
 	tid.prefix = other.prefix
 	tid.suffix = other.suffix
 }
@@ -175,7 +175,7 @@ func validateSuffix(suffix string) error {
 
 type typeIDPointer[T any] interface {
 	*T
-	CopyFrom(other TypeID)
+	copyFrom(other TypeID)
 }
 
 func New2[T any, P typeIDPointer[T]]() (T, error) {
@@ -184,9 +184,8 @@ func New2[T any, P typeIDPointer[T]]() (T, error) {
 	if err != nil {
 		return newID, err
 	}
-	var newIDPtr P = &newID
-	newIDPtr.CopyFrom(tid)
-	return *newIDPtr, nil
+	P(&newID).copyFrom(tid)
+	return newID, nil
 }
 
 var prefixMap = map[reflect.Type]string{}

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -11,8 +11,13 @@ import (
 
 // TypeID is a unique identifier with a given type as defined by the TypeID spec
 type TypeID struct {
+	Copier
 	prefix string
 	suffix string
+}
+
+type Copier interface {
+	CopyFrom(other TypeID)
 }
 
 // Nil represents an the null TypeID
@@ -172,11 +177,12 @@ func validateSuffix(suffix string) error {
 	return nil
 }
 
-type Unimplementable interface {
-	dummy() dummy
+type Unimplementable[T any] interface {
+	unimplementable(T) unimplementable
 }
-type dummy any
+type unimplementable any
 
-func (tid TypeID) dummy() dummy {
+// nolint: unused
+func (tid TypeID) unimplementable(TypeID) unimplementable {
 	return nil
 }

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -11,7 +11,6 @@ import (
 
 // TypeID is a unique identifier with a given type as defined by the TypeID spec
 type TypeID struct {
-	Copier
 	prefix string
 	suffix string
 }
@@ -19,6 +18,9 @@ type TypeID struct {
 type Copier interface {
 	CopyFrom(other TypeID)
 }
+
+// Enforce that TypeID pointer implements the Copier interface
+var _ Copier = &TypeID{}
 
 // Nil represents an the null TypeID
 var Nil = TypeID{

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -173,12 +173,12 @@ func validateSuffix(suffix string) error {
 	return nil
 }
 
-type TypeIDPointer[T any] interface {
+type typeIDPointer[T any] interface {
 	*T
 	CopyFrom(other TypeID)
 }
 
-func New2[T any, P TypeIDPointer[T]]() (T, error) {
+func New2[T any, P typeIDPointer[T]]() (T, error) {
 	var newID T
 	tid, err := New(typeFromTag(newID))
 	if err != nil {
@@ -191,8 +191,6 @@ func New2[T any, P TypeIDPointer[T]]() (T, error) {
 
 var prefixMap = map[reflect.Type]string{}
 
-// tp could be a untyped.TypeID type, but I don't want to check type inside
-// the typeOf function.
 func typeFromTag(tp any) string {
 	t := reflect.TypeOf(tp)
 	if prefix, ok := prefixMap[t]; ok {

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -66,6 +66,11 @@ func (tid TypeID) UUID() string {
 	return uuid.FromBytesOrNil(tid.UUIDBytes()).String()
 }
 
+func (tid *TypeID) CopyFrom(other TypeID) {
+	tid.prefix = other.prefix
+	tid.suffix = other.suffix
+}
+
 // From returns a new TypeID with the given prefix and suffix.
 // If suffix is the empty string, a random suffix will be generated.
 // If you want to create an id without a prefix, pass an empty string as the prefix.
@@ -164,5 +169,14 @@ func validateSuffix(suffix string) error {
 	if _, err := base32.Decode(suffix); err != nil {
 		return fmt.Errorf("invalid suffix: %w", err)
 	}
+	return nil
+}
+
+type Unimplementable interface {
+	dummy() dummy
+}
+type dummy any
+
+func (tid TypeID) dummy() dummy {
 	return nil
 }


### PR DESCRIPTION
## Summary

Prototype of typed typeid using struct tags. 

**This implementation is fully backwards compatible**

 This shows the change:

Previously:

```golang
type orgPrefix struct{}

func (orgPrefix) Type() string { return "org" }

type OrgID struct{ typeid.TypeID[orgPrefix] }
```

New:

```golang
type OrgID struct {
  untypeid.TypeID `prefix:"org"`
}
```

To create a new ID, we use same function as before (thus backward compatible)

```golang
orgID, err := typeid.New[OrgID]()
// orgID is of type typeid.TypeID[OrgID]
```

**Non backwards compatible option**

`New` returns `TypeID[T]` which is not ideal. It means that the struct is not the actual ID (it just represents the prefix). I also implemented a new non-backwards compatible version of `New` called `New2` which returns `T` instead. 

New2:

```golang
orgID, err := typeid.New2[OrgID]()
// orgID is of type OrgID
```

## How was it tested?

Ran test script.

Performance:

* `New2` is about 5% faster than old `New`

