### PR TITLE
[easy][important] Fix build by propagating failures per go module

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -9,12 +9,12 @@
     ],
     "scripts": {
       "go-mod-sync": [
-        "find . -maxdepth 4 -type f -name go.mod -execdir go mod tidy \\;",
+        "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go mod tidy\"",
         "go work sync"
       ],
-      "build": "find . -maxdepth 4 -type f -name go.mod -execdir go build -v ./... \\;",
+      "build": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go build -v ./...\"",
       "lint": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && golangci-lint run --timeout 300s\"",
-      "test": "find . -maxdepth 4 -type f -name go.mod -execdir go test -v ./... \\;"
+      "test": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go test -v ./...\""
     }
   }
 }

--- a/envsec/go.mod
+++ b/envsec/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.38.1
 	github.com/spf13/cobra v1.7.0
-	go.jetpack.io/pkg v0.0.0-20231110160104-d72c97e89959
+	go.jetpack.io/pkg v0.0.0-20231110225622-e71b38cc696e
 	golang.org/x/text v0.13.0
 )
 

--- a/envsec/go.sum
+++ b/envsec/go.sum
@@ -111,8 +111,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.jetpack.io/pkg v0.0.0-20231110160104-d72c97e89959 h1:dMCXvqu0ecLm3cutTTTt3oeI+rgqX33d65yFEqnwqOw=
-go.jetpack.io/pkg v0.0.0-20231110160104-d72c97e89959/go.mod h1:kNS2CEFrjrOlkBRDygQddqnzrml66T0L3Hh82HeLSjw=
+go.jetpack.io/pkg v0.0.0-20231110225622-e71b38cc696e h1:s/OA4hdAGkqVLuk+0lJ9iU+2aGvvmrgBEX2QfAxi5xo=
+go.jetpack.io/pkg v0.0.0-20231110225622-e71b38cc696e/go.mod h1:kNS2CEFrjrOlkBRDygQddqnzrml66T0L3Hh82HeLSjw=
 go.jetpack.io/typeid v0.1.0 h1:suTmjNR3y2em2gCTG06agFfcACm3+zuxfziMUk5UXnw=
 go.jetpack.io/typeid v0.1.0/go.mod h1:E11ObFkKlvsSTxwwYIm+zpbsRthjIMDy/JGBogs2vSo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Summary
Our current devbox scripts use find to run commands inside each of our go modules. However, as written, the scripts return
the exit code of find and not of the executed command. So, if tests fail in one of the go modules, the devbox script still succeeds, because it "found" what we asked it to find.

Rewrite the scripts using `xargs` so that the exit code is correctly propagated.

## How was it tested?
Broke a test, verified it propagates.