### PR TITLE
[easy][important] Disable go.mod checks in opensource CI/CD

### DIFF
--- a/.github/workflows/monorepo-go.yml
+++ b/.github/workflows/monorepo-go.yml
@@ -32,10 +32,12 @@ jobs:
             ~/go/pkg
           key: ${{ runner.os }}-${{ hashFiles('go.work.sum') }}
 
-      - name: Go modules should be up-to-date
-        run: |
-          devbox run go-mod-sync
-          git diff --exit-code
+      # Disable this check until we figure out how to solve for
+      # the 'publish repos twice' problem
+      # - name: Go modules should be up-to-date
+      #   run: |
+      #     devbox run go-mod-sync
+      #     git diff --exit-code
           
       - name: Lint
         run: devbox run lint


### PR DESCRIPTION
## Summary
TSIA. Note that this right now is creating a bad 'circular dependency'. The go.mod can't be updated, because the most recent code is not published. But the most recent code can't be published, because we only publish if the build is green.

## How was it tested?
N/A