### PR TITLE
Improve TypeID interfaces

### DIFF
--- a/envsec/go.sum
+++ b/envsec/go.sum
@@ -41,6 +41,7 @@ github.com/charmbracelet/lipgloss v0.8.0/go.mod h1:p4eYUZZJ/0oXTuCQKFF8mqyKCz0ja
 github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
 github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -82,6 +83,7 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
@@ -108,6 +110,7 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -122,6 +125,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.15.0 h1:frVn1TEaCEaZcn3Tmd7Y2b5KKPaZ+I32Q2OA3kYp5TA=
+golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -11,6 +11,7 @@ github.com/codeclysm/extract/v3 v3.1.1 h1:iHZtdEAwSTqPrd+1n4jfhr1qBhUWtHlMTjT90+
 github.com/codeclysm/extract/v3 v3.1.1/go.mod h1:ZJi80UG2JtfHqJI+lgJSCACttZi++dHxfWuPaMhlOfQ=
 github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
 github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -68,6 +69,7 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
@@ -81,6 +83,7 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -96,6 +99,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.15.0 h1:frVn1TEaCEaZcn3Tmd7Y2b5KKPaZ+I32Q2OA3kYp5TA=
+golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -116,6 +120,7 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/typeid/typeid-go/bench_test.go
+++ b/typeid/typeid-go/bench_test.go
@@ -118,7 +118,7 @@ func benchUntypedFrom(n int) (string, func(*testing.B)) {
 	ids := make([]struct{ prefix, suffix string }, n)
 	for i := range ids {
 		id := typeid.Must(typeid.WithPrefix("prefix"))
-		ids[i].prefix, ids[i].suffix = id.Type(), id.Suffix()
+		ids[i].prefix, ids[i].suffix = id.Prefix(), id.Suffix()
 	}
 	return fmt.Sprintf("n=%d", n), func(b *testing.B) {
 		b.ReportAllocs()

--- a/typeid/typeid-go/constructors.go
+++ b/typeid/typeid-go/constructors.go
@@ -19,7 +19,7 @@ import (
 //		   typeid.TypeID[UserPrefix]
 //	  }
 //	  id, err := typeid.New[UserID]()
-func New[T Subtype, PT subtypePtr[T]]() (T, error) {
+func New[T Subtype, PT SubtypePtr[T]]() (T, error) {
 	if isAnyID[T]() {
 		var id T
 		return id, errors.New("constructor error: use WithPrefix(), New() is for Subtypes")
@@ -51,7 +51,7 @@ func From(prefix string, suffix string) (AnyID, error) {
 //		   typeid.TypeID[UserPrefix]
 //	  }
 //	  id, err := typeid.FromSuffix[UserID]("00041061050r3gg28a1c60t3gf")
-func FromSuffix[T Subtype, PT subtypePtr[T]](suffix string) (T, error) {
+func FromSuffix[T Subtype, PT SubtypePtr[T]](suffix string) (T, error) {
 	if isAnyID[T]() {
 		var id T
 		return id, errors.New("constructor error: use From(prefix, suffix), FromSuffix is for Subtypes")
@@ -75,7 +75,7 @@ func FromString(s string) (AnyID, error) {
 //		   typeid.TypeID[UserPrefix]
 //	  }
 //	  id, err := typeid.Parse[UserID]("user_00041061050r3gg28a1c60t3gf")
-func Parse[T Subtype, PT subtypePtr[T]](s string) (T, error) {
+func Parse[T Subtype, PT SubtypePtr[T]](s string) (T, error) {
 	prefix, suffix, err := split(s)
 	if err != nil {
 		var id T
@@ -99,7 +99,7 @@ func split(id string) (string, string, error) {
 }
 
 // FromUUID encodes the given UUID (in hex string form) as a TypeID with the given prefix.
-func FromUUID[T Subtype, PT subtypePtr[T]](prefix string, uidStr string) (T, error) {
+func FromUUID[T Subtype, PT SubtypePtr[T]](prefix string, uidStr string) (T, error) {
 	uid, err := uuid.FromString(uidStr)
 	var nilID T
 
@@ -111,12 +111,12 @@ func FromUUID[T Subtype, PT subtypePtr[T]](prefix string, uidStr string) (T, err
 }
 
 // FromUUID encodes the given UUID (in byte form) as a TypeID with the given prefix.
-func FromUUIDBytes[T Subtype, PT subtypePtr[T]](prefix string, bytes []byte) (T, error) {
+func FromUUIDBytes[T Subtype, PT SubtypePtr[T]](prefix string, bytes []byte) (T, error) {
 	uidStr := uuid.FromBytesOrNil(bytes).String()
 	return FromUUID[T, PT](prefix, uidStr)
 }
 
-func from[T Subtype, PT subtypePtr[T]](prefix string, suffix string) (T, error) {
+func from[T Subtype, PT SubtypePtr[T]](prefix string, suffix string) (T, error) {
 	var tid T
 	if err := validatePrefix[T](prefix); err != nil {
 		return tid, err

--- a/typeid/typeid-go/subtype.go
+++ b/typeid/typeid-go/subtype.go
@@ -4,13 +4,18 @@ package typeid
 // For example, if you want to create an `OrgID` type that only accepts
 // an `org_` prefix.
 type Subtype interface {
-	Type() string
+	Prefix() string
+	Suffix() string
+	String() string
+	UUIDBytes() []byte
+	UUID() string
+
 	isTypeID() bool
 }
 
-// var _ Subtype = (*TypeID[Any])(nil)
+var _ Subtype = (*TypeID[AnyPrefix])(nil)
 
-type subtypePtr[T any] interface {
+type SubtypePtr[T any] interface {
 	*T
 	init(prefix string, suffix string)
 }
@@ -51,5 +56,5 @@ func isAnyID[T Subtype]() bool {
 
 func defaultType[T Subtype]() string {
 	var id T
-	return id.Type()
+	return id.Prefix()
 }

--- a/typeid/typeid-go/subtype_example_test.go
+++ b/typeid/typeid-go/subtype_example_test.go
@@ -39,8 +39,8 @@ func Example() {
 	// Other than that, your custom types should have the same methods as a
 	// regular TypeID.
 	// For example, we can check that each ID has the correct type prefix:
-	fmt.Printf("User ID prefix: %s\n", userID.Type())
-	fmt.Printf("Account ID prefix: %s\n", accountID.Type())
+	fmt.Printf("User ID prefix: %s\n", userID.Prefix())
+	fmt.Printf("Account ID prefix: %s\n", accountID.Prefix())
 
 	// Despite both of them being TypeIDs, you now get compile-time safety because
 	// the compiler considers their go types to be different:

--- a/typeid/typeid-go/subtype_test.go
+++ b/typeid/typeid-go/subtype_test.go
@@ -10,14 +10,14 @@ import (
 
 func ExampleNew() {
 	tid := typeid.Must(typeid.New[AccountID]())
-	fmt.Println("Prefix:", tid.Type())
+	fmt.Println("Prefix:", tid.Prefix())
 	// Output:
 	// Prefix: account
 }
 
 func ExampleFromSuffix() {
 	tid := typeid.Must(typeid.FromSuffix[UserID]("00041061050r3gg28a1c60t3gf"))
-	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Type(), tid.Suffix())
+	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Prefix(), tid.Suffix())
 	// Output:
 	// Prefix: user
 	// Suffix: 00041061050r3gg28a1c60t3gf
@@ -43,16 +43,16 @@ func TestSubtypeNil(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, nilUser, emptyUser)
 	assert.Equal(t, nilUser.String(), emptyUser.String())
-	assert.Equal(t, nilUser.Type(), emptyUser.Type())
+	assert.Equal(t, nilUser.Prefix(), emptyUser.Prefix())
 	assert.Equal(t, nilUser.UUID(), emptyUser.UUID())
 	assert.Equal(t, nilUser.UUIDBytes(), emptyUser.UUIDBytes())
 	assert.Equal(t, "user_00000000000000000000000000", nilUser.String())
-	assert.Equal(t, "user", nilUser.Type())
+	assert.Equal(t, "user", nilUser.Prefix())
 
 	parsed, err := typeid.FromString("user_00000000000000000000000000")
 	assert.NoError(t, err)
 	assert.Equal(t, "user_00000000000000000000000000", parsed.String())
-	assert.Equal(t, "user", parsed.Type())
+	assert.Equal(t, "user", parsed.Prefix())
 	assert.Equal(t, "00000000000000000000000000", parsed.Suffix())
 }
 

--- a/typeid/typeid-go/typeid.go
+++ b/typeid/typeid-go/typeid.go
@@ -11,8 +11,8 @@ type TypeID[P PrefixType] struct {
 	suffix string
 }
 
-// Type returns the type prefix of the TypeID
-func (tid TypeID[P]) Type() string {
+// Prefix returns the type prefix of the TypeID
+func (tid TypeID[P]) Prefix() string {
 	if isAnyPrefix[P]() {
 		return tid.prefix
 	}
@@ -33,10 +33,10 @@ func (tid TypeID[P]) Suffix() string {
 // String returns the TypeID in it's canonical string representation of the form:
 // <prefix>_<suffix> where <suffix> is the canonical base32 representation of the UUID
 func (tid TypeID[P]) String() string {
-	if tid.Type() == "" {
+	if tid.Prefix() == "" {
 		return tid.Suffix()
 	}
-	return tid.Type() + "_" + tid.Suffix()
+	return tid.Prefix() + "_" + tid.Suffix()
 }
 
 // UUIDBytes decodes the TypeID's suffix as a UUID and returns it's bytes

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -22,7 +22,7 @@ func ExampleWithPrefix_emptyPrefix() {
 
 func ExampleFromString() {
 	tid := typeid.Must(typeid.FromString("prefix_00041061050r3gg28a1c60t3gf"))
-	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Type(), tid.Suffix())
+	fmt.Printf("Prefix: %s\nSuffix: %s\n", tid.Prefix(), tid.Suffix())
 	// Output:
 	// Prefix: prefix
 	// Suffix: 00041061050r3gg28a1c60t3gf
@@ -193,8 +193,8 @@ func TestValidTestdata(t *testing.T) {
 			if td.UUID != tid.UUID() {
 				t.Errorf("Expected %s, got %s", td.UUID, tid.UUID())
 			}
-			if td.Prefix != tid.Type() {
-				t.Errorf("Expected %s, got %s", td.Prefix, tid.Type())
+			if td.Prefix != tid.Prefix() {
+				t.Errorf("Expected %s, got %s", td.Prefix, tid.Prefix())
 			}
 		})
 	}

--- a/typeid/typeid/cli/decode.go
+++ b/typeid/typeid/cli/decode.go
@@ -23,7 +23,7 @@ func decodeCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	cmd.Printf("type: %s\n", tid.Type())
+	cmd.Printf("type: %s\n", tid.Prefix())
 	cmd.Printf("uuid: %s\n", tid.UUID())
 	return nil
 }

--- a/tyson/go.sum
+++ b/tyson/go.sum
@@ -1,6 +1,7 @@
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=
 github.com/chzyer/test v0.0.0-20210722231415-061457976a23/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -47,6 +48,7 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
@@ -84,6 +86,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
+golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
Improvements to TypeID interfaces:
- Add all the standard TypeID methods to the `Subtype` interfaces. When changing code in axiom, noticed that would be useful.
- Make `SubtypePtr` public. Occasionally useful, if one needs to create a 'constructor'-like function outside the `typeid` package.
- Rename `Type()` to `Prefix()`. Been wanting to do this change before. After using typeids, I think `Prefix()` feels more natural and it pairs nicely with the existing `Suffix()`. This change is *not* backwards compatible, but neither was the generics change we did. I'm hoping I can get this in now, and then tag the next release as `v1`.

## How was it tested?
Ran all tests.