### PR TITLE
[opensource] Improve root-level devbox.json

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -9,12 +9,13 @@
     ],
     "scripts": {
       "go-mod-sync": [
-        "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go mod tidy\"",
+        "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo mod '{}' && go mod tidy\"",
         "go work sync"
       ],
-      "build": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go build -v ./...\"",
-      "lint": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && golangci-lint run --timeout 300s\"",
-      "test": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && go test -v ./...\""
+      "build": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo build '{}' && go build -v ./...\"",
+      "lint": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo lint '{}' && golangci-lint run --fix --timeout 300s\"",
+      "fmt": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo fmt '{}' && go fmt ./...\"",
+      "test": "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo test '{}' && go test -race -cover -v ./...\""
     }
   }
 }


### PR DESCRIPTION
## Summary
Improves the scripts in our root-level devbox.json:
- Each script now prints what directory it's working on
- Linting by default tries to fix issues when it can
- Added a `fmt` script.

## How was it tested?
Ran locally