### PR TITLE
[envsec] use ENVSEC_JETPACK_API_ENDPOINT to override

### DIFF
--- a/envsec/devbox.json
+++ b/envsec/devbox.json
@@ -11,7 +11,17 @@
     "scripts": {
       "build": "go build -o dist/envsec cmd/envsec/main.go",
       "lint": "golangci-lint run -c ../.golangci.yml",
-      "test": "go test ./..."
+      "test": "go test ./...",
+      "login-dev": [
+       "echo 'WARNING: auth-service from frontend must be running locally'",
+       "export ENVSEC_CLIENT_ID=3945b320-bd31-4313-af27-846b67921acb",
+        "export ENVSEC_ISSUER=https://laughing-agnesi-vzh2rap9f6.projects.oryapis.com",
+        "export ENVSEC_JETPACK_API_ENDPOINT=https://apisvc-6no3bdensq-uk.a.run.app",
+        // set ENVSEC_JETPACK_API_ENDPOINT to localhost:8080 if running apisvc locally
+        "export ENVSEC_JETPACK_API_ENDPOINT=http://localhost:8080",
+        "devbox run build",
+        "dist/envsec auth login",
+      ],
     }
   },
   "nixpkgs": {

--- a/envsec/envsec.go
+++ b/envsec/envsec.go
@@ -5,6 +5,7 @@ package envsec
 
 import (
 	"context"
+	"os"
 	"path"
 
 	"github.com/pkg/errors"
@@ -120,9 +121,6 @@ type JetpackAPIConfig struct {
 // prodJetpackAPIEndpoint is used for production.
 const prodJetpackAPIEndpoint = "https://api.jetpack.io"
 
-// localhostJetpackAPIEndpoint is used for local development.
-// const localhostJetpackAPIEndpoint = "http://localhost:8080"
-
 // JetpackAPIStore implements interface Config (compile-time check)
 var _ Config = (*JetpackAPIConfig)(nil)
 
@@ -131,9 +129,9 @@ func (c *JetpackAPIConfig) IsEnvStoreConfig() bool {
 }
 
 func NewJetpackAPIConfig(token string) *JetpackAPIConfig {
-	return &JetpackAPIConfig{
-		endpoint: prodJetpackAPIEndpoint,
-		// endpoint: localhostJetpackAPIEndpoint,
-		token: token,
+	endpoint := prodJetpackAPIEndpoint
+	if e := os.Getenv("ENVSEC_JETPACK_API_ENDPOINT"); e != "" {
+		endpoint = e
 	}
+	return &JetpackAPIConfig{endpoint, token}
 }

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -112,7 +112,7 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 	store, err := envsec.NewStore(ctx, ssmConfig)
 
 	// Uncomment this to use the Jetpack API instead of AWS SSM store
-	// store, err := envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
+	// store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
 
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
## Summary

Also adds `devbox run login-dev` as a convenience command to get the dev 
access-token and id-token locally.

NOTE: 
here, the env-var's default value is the prod value. This is consistent with ENVSEC_CLIENT_ID and ENVSEC_ISSUER behavior (but different from what we do in apisvc)

## How was it tested?

did `devbox run login-dev` and verified the access token
