### PR TITLE
[envsec CLI] add dev mode

### DIFF
--- a/envsec/devbox.json
+++ b/envsec/devbox.json
@@ -14,13 +14,10 @@
       "test": "go test ./...",
       "login-dev": [
        "echo 'WARNING: auth-service from frontend must be running locally'",
-       "export ENVSEC_CLIENT_ID=3945b320-bd31-4313-af27-846b67921acb",
-        "export ENVSEC_ISSUER=https://laughing-agnesi-vzh2rap9f6.projects.oryapis.com",
-        "export ENVSEC_JETPACK_API_ENDPOINT=https://apisvc-6no3bdensq-uk.a.run.app",
         // set ENVSEC_JETPACK_API_ENDPOINT to localhost:8080 if running apisvc locally
         // "export ENVSEC_JETPACK_API_ENDPOINT=http://localhost:8080",
-        "devbox run build",
-        "dist/envsec auth login",
+        "echo 'building envsec.' && devbox run build",
+        "dist/envsec auth login --dev",
       ],
     }
   },

--- a/envsec/envsec.go
+++ b/envsec/envsec.go
@@ -121,6 +121,9 @@ type JetpackAPIConfig struct {
 // prodJetpackAPIEndpoint is used for production.
 const prodJetpackAPIEndpoint = "https://api.jetpack.io"
 
+// devJetpackAPIEndpoint is used for development.
+const devJetpackAPIEndpoint = "https://apisvc-6no3bdensq-uk.a.run.app"
+
 // JetpackAPIStore implements interface Config (compile-time check)
 var _ Config = (*JetpackAPIConfig)(nil)
 
@@ -130,6 +133,9 @@ func (c *JetpackAPIConfig) IsEnvStoreConfig() bool {
 
 func NewJetpackAPIConfig(token string) *JetpackAPIConfig {
 	endpoint := prodJetpackAPIEndpoint
+	if IsDevMode() {
+		endpoint = devJetpackAPIEndpoint
+	}
 	if e := os.Getenv("ENVSEC_JETPACK_API_ENDPOINT"); e != "" {
 		endpoint = e
 	}

--- a/envsec/pkg/envcli/auth.go
+++ b/envsec/pkg/envcli/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"go.jetpack.io/envsec"
 	"go.jetpack.io/pkg/auth"
 	"go.jetpack.io/pkg/envvar"
 )
@@ -126,8 +127,18 @@ func whoAmICmd() *cobra.Command {
 }
 
 func newAuthClient() (*auth.Client, error) {
-	issuer := envvar.Get("ENVSEC_ISSUER", "https://accounts.jetpack.io")
-	clientID := envvar.Get("ENVSEC_CLIENT_ID", "ff3d4c9c-1ac8-42d9-bef1-f5218bb1a9f6")
+	defaultIssuer := "https://accounts.jetpack.io"
+	if envsec.IsDevMode() {
+		defaultIssuer = "https://laughing-agnesi-vzh2rap9f6.projects.oryapis.com"
+	}
+	issuer := envvar.Get("ENVSEC_ISSUER", defaultIssuer)
+
+	defaultClientID := "ff3d4c9c-1ac8-42d9-bef1-f5218bb1a9f6"
+	if envsec.IsDevMode() {
+		defaultClientID = "3945b320-bd31-4313-af27-846b67921acb"
+	}
+	clientID := envvar.Get("ENVSEC_CLIENT_ID", defaultClientID)
+
 	// TODO: Consider making scopes and audience configurable:
 	// "ENVSEC_AUTH_SCOPE" = "openid offline_access email profile"
 	// "ENVSEC_AUTH_AUDIENCE" = "https://api.jetpack.io",

--- a/envsec/util.go
+++ b/envsec/util.go
@@ -4,8 +4,14 @@
 package envsec
 
 import (
+	"os"
+	"strconv"
 	"strings"
 )
+
+// isDev determines whether we are running in dev mode, by default.
+// Specific settings may still be overridable by specific env-vars.
+var isDev bool = false
 
 func nameFromPath(path string) string {
 	subpaths := strings.Split(path, "/")
@@ -13,4 +19,17 @@ func nameFromPath(path string) string {
 		return ""
 	}
 	return subpaths[len(subpaths)-1]
+}
+
+func SetDevMode(dev bool) {
+	isDev = dev
+}
+
+func IsDevMode() bool {
+	devEnv := os.Getenv("ENVSEC_DEV")
+	if devEnv != "" {
+		isDev, err := strconv.ParseBool(devEnv)
+		return err == nil && isDev
+	}
+	return isDev
 }


### PR DESCRIPTION
## Summary

To enable dev-apisvc, users should set both of:
1. `ENVSEC_USE_AWS_STORAGE=0` 
2.  use `--dev` flag or set `ENVSEC_DEV=1`

**Motivation**:
1. This adds `--dev` to all commands to trigger dev-mode.

However, it's not ideal since it requires `--dev` to be used in every command which is easy
to forget. So, I also enable the user to set ENVSEC_DEV=1 to trigger dev-mode.

2. for now, users will still also have to set `ENVSEC_USE_AWS_STORAGE=0` until we migrate all our services to use Unified API in prod.




## How was it tested?
```
devbox run login-dev

# get access token
envsec auth whoami --show-tokens --dev
# open in jwt.io and verify the issuer is `agnes`-and-friends and not accounts.jetpack.io
```