### PR TITLE
[envsec CLI]  use dev-apisvc for all envsec operations in dev-mode, including CreateProject 

### DIFF
--- a/envsec/jetpack_api_store.go
+++ b/envsec/jetpack_api_store.go
@@ -155,8 +155,8 @@ func (j JetpackAPIStore) client() secretsv1alpha1connect.SecretsServiceClient {
 	return secretsv1alpha1connect.NewSecretsServiceClient(
 		http.DefaultClient,
 		j.config.host,
-		// TODO: Do we want grpc?
-		connect.WithGRPC(),
+		// TODO: Do we want grpc? For now, we don't want it.
+		// connect.WithGRPC(),
 	)
 }
 

--- a/envsec/jetpack_api_store.go
+++ b/envsec/jetpack_api_store.go
@@ -152,12 +152,7 @@ func (j JetpackAPIStore) DeleteAll(ctx context.Context, envID EnvID, names []str
 }
 
 func (j JetpackAPIStore) client() secretsv1alpha1connect.SecretsServiceClient {
-	return secretsv1alpha1connect.NewSecretsServiceClient(
-		http.DefaultClient,
-		j.config.host,
-		// TODO: Do we want grpc? For now, we don't want it.
-		// connect.WithGRPC(),
-	)
+	return secretsv1alpha1connect.NewSecretsServiceClient(http.DefaultClient, j.config.host)
 }
 
 func newRequest[T any](message *T, token string) *connect.Request[T] {

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -56,8 +56,8 @@ func (f *configFlags) validateProjectID(orgID id.OrgID) (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	jc := jetcloud.JetCloud{APIHost: build.JetpackAPIHost(), IsDev: build.IsDev}
-	config, err := jc.ProjectConfig(wd)
+	c := jetcloud.Client{ApiHost: build.JetpackAPIHost(), IsDev: build.IsDev}
+	config, err := c.ProjectConfig(wd)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf(
 			"project ID not specified. You must run `envsec init` or specify --project-id in this directory",

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -56,7 +56,7 @@ func (f *configFlags) validateProjectID(orgID id.OrgID) (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	c := jetcloud.Client{ApiHost: build.JetpackAPIHost(), IsDev: build.IsDev}
+	c := jetcloud.Client{APIHost: build.JetpackAPIHost(), IsDev: build.IsDev}
 	config, err := c.ProjectConfig(wd)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf(

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec"
+	"go.jetpack.io/envsec/internal/build"
 	"go.jetpack.io/envsec/pkg/awsfed"
 	"go.jetpack.io/pkg/auth/session"
 	"go.jetpack.io/pkg/id"
@@ -55,7 +56,8 @@ func (f *configFlags) validateProjectID(orgID id.OrgID) (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	config, err := jetcloud.ProjectConfig(wd)
+	jc := jetcloud.JetCloud{APIHost: build.JetpackAPIHost(), IsDev: build.IsDev}
+	config, err := jc.ProjectConfig(wd)
 	if errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf(
 			"project ID not specified. You must run `envsec init` or specify --project-id in this directory",
@@ -105,14 +107,25 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 		}
 	}
 
-	ssmConfig, err := awsfed.GenSSMConfigFromToken(ctx, tok, true /*useCache*/)
-	if err != nil {
-		return nil, errors.WithStack(err)
+	var store envsec.Store
+	if !build.IsDev {
+		// Temporarily use the SSM config until prod-apisvc is ready
+		// AND we migrate all the secrets of services to the new store.
+		ssmConfig, err := awsfed.GenSSMConfigFromToken(ctx, tok, true /*useCache*/)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		store, err = envsec.NewStore(ctx, ssmConfig)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+	} else {
+		// dev-apisvc is ready so we can use it already
+		store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 	}
-	store, err := envsec.NewStore(ctx, ssmConfig)
-
-	// Uncomment this to use the Jetpack API instead of AWS SSM store
-	// store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
 
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.jetpack.io/envsec/internal/build"
 	"go.jetpack.io/pkg/jetcloud"
 )
 
@@ -24,12 +25,20 @@ func initCmd() *cobra.Command {
 				return fmt.Errorf("error: %w, run `envsec auth login`", err)
 			}
 
-			wd, err := os.Getwd()
+			workdir, err := os.Getwd()
 			if err != nil {
 				return err
 			}
 
-			projectID, err := jetcloud.InitProject(cmd.Context(), tok, wd)
+			apiHost := build.JetpackAPIHost()
+			if !build.IsDev {
+				// Temporarily continue to use envsec-service in prod
+				// until prod-apisvc is ready.
+				apiHost = "https://envsec-service-prod.cloud.jetpack.dev"
+			}
+
+			c := jetcloud.JetCloud{APIHost: apiHost, IsDev: build.IsDev}
+			projectID, err := c.InitProject(cmd.Context(), tok, workdir)
 			if errors.Is(err, jetcloud.ErrProjectAlreadyInitialized) {
 				fmt.Fprintf(
 					cmd.ErrOrStderr(),

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -37,7 +37,7 @@ func initCmd() *cobra.Command {
 				apiHost = "https://envsec-service-prod.cloud.jetpack.dev"
 			}
 
-			c := jetcloud.JetCloud{APIHost: apiHost, IsDev: build.IsDev}
+			c := jetcloud.Client{ApiHost: apiHost, IsDev: build.IsDev}
 			projectID, err := c.InitProject(cmd.Context(), tok, workdir)
 			if errors.Is(err, jetcloud.ErrProjectAlreadyInitialized) {
 				fmt.Fprintf(

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -37,7 +37,7 @@ func initCmd() *cobra.Command {
 				apiHost = "https://envsec-service-prod.cloud.jetpack.dev"
 			}
 
-			c := jetcloud.Client{ApiHost: apiHost, IsDev: build.IsDev}
+			c := jetcloud.Client{APIHost: apiHost, IsDev: build.IsDev}
 			projectID, err := c.InitProject(cmd.Context(), tok, workdir)
 			if errors.Is(err, jetcloud.ErrProjectAlreadyInitialized) {
 				fmt.Fprintf(

--- a/pkg/jetcloud/client.go
+++ b/pkg/jetcloud/client.go
@@ -18,7 +18,7 @@ import (
 // Client manages state for interacting with the JetCloud API, as well as
 // communicating with the JetCloud API.
 type Client struct {
-	ApiHost string
+	APIHost string
 	IsDev   bool
 }
 
@@ -29,7 +29,7 @@ type errorResponse struct {
 }
 
 func (c *Client) endpoint(path string) string {
-	endpointURL, err := url.JoinPath(c.ApiHost, path)
+	endpointURL, err := url.JoinPath(c.APIHost, path)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/jetcloud/client.go
+++ b/pkg/jetcloud/client.go
@@ -25,13 +25,13 @@ type errorResponse struct {
 	} `json:"error"`
 }
 
-func (s *JetCloud) newClient() *client {
-	if s.APIHost == "" {
+func (jc *JetCloud) newClient() *client {
+	if jc.APIHost == "" {
 		// This is the dev api.jetpack.io URL
-		s.APIHost = "https://apisvc-6no3bdensq-uk.a.run.app"
+		jc.APIHost = "https://apisvc-6no3bdensq-uk.a.run.app"
 	}
 	return &client{
-		apiHost: s.APIHost,
+		apiHost: jc.APIHost,
 	}
 }
 
@@ -46,12 +46,10 @@ func (c *client) endpoint(path string) string {
 func (c *client) newProjectID(ctx context.Context, tok *session.Token, repo, subdir string) (id.ProjectID, error) {
 	p, err := post[struct {
 		ID id.ProjectID `json:"id"`
-	}](
-		ctx, c, tok, "projects", map[string]string{
-			"repo_url": repo,
-			"subdir":   subdir,
-		},
-	)
+	}](ctx, c, tok, "projects", map[string]string{
+		"repo_url": repo,
+		"subdir":   subdir,
+	})
 	if err != nil {
 		return id.ProjectID{}, err
 	}


### PR DESCRIPTION
## Summary

This PR lets us use dev-apisvc for all envsec operations in dev-mode, including
CreateProject (which this PR also hooks up)

## How was it tested?

1. `envsec init` in a new project. Saw `.jetpack.io/dev.project.json` created
2. `envsec ls` and `envsec set` do work
