### PR TITLE
[apisvc] use apisvc for prod (in anticipation of apisvc being ready)

### DIFF
--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec"
 	"go.jetpack.io/envsec/internal/build"
-	"go.jetpack.io/envsec/pkg/awsfed"
 	"go.jetpack.io/pkg/auth/session"
 	"go.jetpack.io/pkg/id"
 	"go.jetpack.io/pkg/jetcloud"
@@ -107,24 +106,9 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 		}
 	}
 
-	var store envsec.Store
-	if !build.IsDev {
-		// Temporarily use the SSM config until prod-apisvc is ready
-		// AND we migrate all the secrets of services to the new store.
-		ssmConfig, err := awsfed.GenSSMConfigFromToken(ctx, tok, true /*useCache*/)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		store, err = envsec.NewStore(ctx, ssmConfig)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-	} else {
-		// dev-apisvc is ready so we can use it already
-		store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
+	store, err := envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
 
 	if err != nil {

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -30,14 +30,7 @@ func initCmd() *cobra.Command {
 				return err
 			}
 
-			apiHost := build.JetpackAPIHost()
-			if !build.IsDev {
-				// Temporarily continue to use envsec-service in prod
-				// until prod-apisvc is ready.
-				apiHost = "https://envsec-service-prod.cloud.jetpack.dev"
-			}
-
-			c := jetcloud.Client{APIHost: apiHost, IsDev: build.IsDev}
+			c := jetcloud.Client{APIHost: build.JetpackAPIHost(), IsDev: build.IsDev}
 			projectID, err := c.InitProject(cmd.Context(), tok, workdir)
 			if errors.Is(err, jetcloud.ErrProjectAlreadyInitialized) {
 				fmt.Fprintf(


### PR DESCRIPTION
## Summary

In anticipation of prod-apisvc being ready, i switch to using it for both
`envsec init` and the envsec.Store.

In the future, we can introduce an option for selecting the AWS store (design TBD)

## How was it tested?

compiles
