### PR TITLE
[envsec] enable prod-apisvc by default, with fallback to aws via env-var

### DIFF
--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -13,6 +13,7 @@ import (
 	"go.jetpack.io/envsec/internal/build"
 	"go.jetpack.io/envsec/pkg/awsfed"
 	"go.jetpack.io/pkg/auth/session"
+	"go.jetpack.io/pkg/envvar"
 	"go.jetpack.io/pkg/id"
 	"go.jetpack.io/pkg/jetcloud"
 	"go.jetpack.io/typeid"
@@ -108,9 +109,8 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 	}
 
 	var store envsec.Store
-	if !build.IsDev {
-		// Temporarily use the SSM config until prod-apisvc is ready
-		// AND we migrate all the secrets of services to the new store.
+	if envvar.Bool("ENVSEC_USE_AWS_STORE") {
+		// Temporary hack to enable the AWS store
 		ssmConfig, err := awsfed.GenSSMConfigFromToken(ctx, tok, true /*useCache*/)
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -120,7 +120,6 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 			return nil, errors.WithStack(err)
 		}
 	} else {
-		// dev-apisvc is ready so we can use it already
 		store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.jetpack.io/envsec/internal/build"
+	"go.jetpack.io/pkg/envvar"
 	"go.jetpack.io/pkg/jetcloud"
 )
 
@@ -31,9 +32,8 @@ func initCmd() *cobra.Command {
 			}
 
 			apiHost := build.JetpackAPIHost()
-			if !build.IsDev {
-				// Temporarily continue to use envsec-service in prod
-				// until prod-apisvc is ready.
+			if envvar.Bool("ENVSEC_USE_AWS_STORE") {
+				// Temporary hack to use the AWS store
 				apiHost = "https://envsec-service-prod.cloud.jetpack.dev"
 			}
 

--- a/pkg/envvar/envvar.go
+++ b/pkg/envvar/envvar.go
@@ -5,6 +5,7 @@ package envvar
 
 import (
 	"os"
+	"strconv"
 )
 
 // Get gets the value of an environment variable.
@@ -16,4 +17,14 @@ func Get(key, def string) string {
 	}
 
 	return val
+}
+
+func Bool(key string) bool {
+	val := os.Getenv(key)
+	if val == "" {
+		return false
+	}
+
+	b, err := strconv.ParseBool(val)
+	return err != nil && b
 }

--- a/pkg/envvar/envvar.go
+++ b/pkg/envvar/envvar.go
@@ -26,5 +26,5 @@ func Bool(key string) bool {
 	}
 
 	b, err := strconv.ParseBool(val)
-	return err != nil && b
+	return err == nil && b
 }


### PR DESCRIPTION
## Summary

1. use apisvc by default for prod and dev
2. have a temporary fallback via ENVSEC_USE_AWS_STORE for the previous storage

## How was it tested?

```
export ENVSEC_PROD=1
envsec init # created .jetpack.io/project.json
envsec set FOO=bar
envsec ls
```
