### PR TITLE
[envsec] Add CICD tests

### DIFF
--- a/envsec/.github/workflows/release.yml
+++ b/envsec/.github/workflows/release.yml
@@ -16,7 +16,10 @@ permissions:
   pull-requests: read
 
 jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
   release:
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Monorepo

--- a/envsec/.github/workflows/tests.yml
+++ b/envsec/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: test
+
+on:
+  push:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  monorepo-go:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Monorepo
+        uses: actions/checkout@v3
+
+      - name: Install devbox
+        uses: jetpack-io/devbox-install-action@v0.7.0
+        with:
+          enable-cache: true
+
+      - name: Mount golang cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/golangci-lint
+            ~/.cache/go-build
+            ~/go/pkg
+          key: ${{ runner.os }}-${{ hashFiles('**/*.sum') }}
+
+      - name: Lint
+        run: devbox run lint
+
+      - name: Build
+        run: devbox run build
+
+      - name: Test
+        run: devbox run test


### PR DESCRIPTION
## Summary

This is a bit duplicated with monorepo tests, but because sometimes we forget to update dependencies it's still possible for the envsec build to break. This will let us know. 

## How was it tested?

Will test in CICD
