### PR TITLE
[RFC] Enpasulate envsec init into lib

### DIFF
--- a/envsec/internal/build/build.go
+++ b/envsec/internal/build/build.go
@@ -34,7 +34,7 @@ func ClientID() string {
 
 func JetpackAPIHost() string {
 	if IsDev {
-		return "https://apisvc-6no3bdensq-uk.a.run.app"
+		return "https://api.jetpack.dev"
 	}
 	return "https://api.jetpack.io"
 }

--- a/envsec/pkg/envsec/auth.go
+++ b/envsec/pkg/envsec/auth.go
@@ -1,0 +1,9 @@
+package envsec
+
+import (
+	"go.jetpack.io/pkg/auth"
+)
+
+func (e *Envsec) authClient() (*auth.Client, error) {
+	return auth.NewClient(e.Auth.Issuer, e.Auth.ClientID)
+}

--- a/envsec/pkg/envsec/doc.go
+++ b/envsec/pkg/envsec/doc.go
@@ -1,0 +1,3 @@
+// package envsec contains library functions for working with envsec.
+// if you want to include envsec in your own project, use this package.
+package envsec

--- a/envsec/pkg/envsec/envsec.go
+++ b/envsec/pkg/envsec/envsec.go
@@ -1,0 +1,19 @@
+package envsec
+
+import (
+	"io"
+)
+
+type Envsec struct {
+	APIHost    string
+	Auth       AuthConfig
+	IsDev      bool
+	Stderr     io.Writer
+	WorkingDir string
+}
+
+type AuthConfig struct {
+	Issuer   string
+	ClientID string
+	// TODO AUdiences and Scopes
+}

--- a/envsec/pkg/envsec/init.go
+++ b/envsec/pkg/envsec/init.go
@@ -1,0 +1,46 @@
+package envsec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.jetpack.io/pkg/jetcloud"
+)
+
+type InitProjectArgs struct {
+	Force bool
+}
+
+func (e *Envsec) NewProject(ctx context.Context, force bool) error {
+	var err error
+
+	client, err := e.authClient()
+	if err != nil {
+		return err
+	}
+
+	tok, err := client.GetSession(ctx)
+	if err != nil {
+		return fmt.Errorf("error: %w, run `envsec auth login`", err)
+	}
+
+	c := jetcloud.Client{APIHost: e.APIHost, IsDev: e.IsDev}
+	projectID, err := c.InitProject(ctx, jetcloud.InitProjectArgs{
+		Dir:   e.WorkingDir,
+		Force: force,
+		Token: tok,
+	})
+	if errors.Is(err, jetcloud.ErrProjectAlreadyInitialized) {
+		fmt.Fprintf(
+			e.Stderr,
+			"Warning: project already initialized ID=%s\n",
+			projectID,
+		)
+	} else if err != nil {
+		return err
+	} else {
+		fmt.Fprintf(e.Stderr, "Initialized project ID=%s\n", projectID)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Quick and dirty turning envsec into library. Only did `init` for now but if we agree on structure I'll move the rest.

Ideally everything except flags is in there. 

* Creates new `envsec` package
*  Adds struct with `NewProject` function
* Adds `--force` flag to init.

Thoughts or feedback?

## How was it tested?

`devbox init --force` 