### PR TITLE
[RFC] Remove prefix param when possible

### DIFF
--- a/typeid/typeid-go/bench_test.go
+++ b/typeid/typeid-go/bench_test.go
@@ -246,7 +246,7 @@ func benchUntypedFromBytes(n int) (string, func(*testing.B)) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, id := range ids {
-				typeid.AnyPrefixFromUUIDBytes("prefix", id)
+				typeid.FromUUIDBytesWithPrefix("prefix", id)
 			}
 		}
 		b.ReportMetric(float64(n*b.N)/b.Elapsed().Seconds(), "id/s")
@@ -262,7 +262,7 @@ func benchTypedFromBytes(n int) (string, func(*testing.B)) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, id := range ids {
-				typeid.AnyPrefixFromUUIDBytes("prefix", id)
+				typeid.FromUUIDBytesWithPrefix("prefix", id)
 			}
 		}
 		b.ReportMetric(float64(n*b.N)/b.Elapsed().Seconds(), "id/s")

--- a/typeid/typeid-go/bench_test.go
+++ b/typeid/typeid-go/bench_test.go
@@ -246,7 +246,7 @@ func benchUntypedFromBytes(n int) (string, func(*testing.B)) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, id := range ids {
-				typeid.FromUUIDBytes[typeid.AnyID]("prefix", id)
+				typeid.AnyPrefixFromUUIDBytes("prefix", id)
 			}
 		}
 		b.ReportMetric(float64(n*b.N)/b.Elapsed().Seconds(), "id/s")
@@ -262,7 +262,7 @@ func benchTypedFromBytes(n int) (string, func(*testing.B)) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, id := range ids {
-				typeid.FromUUIDBytes[TestID]("prefix", id)
+				typeid.AnyPrefixFromUUIDBytes("prefix", id)
 			}
 		}
 		b.ReportMetric(float64(n*b.N)/b.Elapsed().Seconds(), "id/s")

--- a/typeid/typeid-go/constructors.go
+++ b/typeid/typeid-go/constructors.go
@@ -9,6 +9,8 @@ import (
 	"go.jetpack.io/typeid/base32"
 )
 
+var ErrConstructor = errors.New("constructor error")
+
 // New returns a new TypeID of the given type with a random suffix.
 //
 // Use the generic argument to pass in your typeid Subtype:
@@ -100,11 +102,25 @@ func split(id string) (string, string, error) {
 
 // FromUUID encodes the given UUID (in hex string form) as a TypeID
 func FromUUID[T Subtype, PT SubtypePtr[T]](uidStr string) (T, error) {
+	if isAnyID[T]() {
+		var id T
+		return id, fmt.Errorf(
+			"%w: use FromUUIDWithPrefix(), FromUUID() is for Subtypes",
+			ErrConstructor,
+		)
+	}
 	return fromUUID[T, PT](defaultPrefix[T](), uidStr)
 }
 
 // FromUUIDBytes encodes the given UUID (in byte form) as a TypeID
 func FromUUIDBytes[T Subtype, PT SubtypePtr[T]](bytes []byte) (T, error) {
+	if isAnyID[T]() {
+		var id T
+		return id, fmt.Errorf(
+			"%w: use FromUUIDBytesWithPrefix(), FromUUIDBytes() is for Subtypes",
+			ErrConstructor,
+		)
+	}
 	uidStr := uuid.FromBytesOrNil(bytes).String()
 	return FromUUID[T, PT](uidStr)
 }

--- a/typeid/typeid-go/constructors.go
+++ b/typeid/typeid-go/constructors.go
@@ -98,8 +98,8 @@ func split(id string) (string, string, error) {
 	}
 }
 
-// FromUUID encodes the given UUID (in hex string form) as a TypeID with the given prefix.
-func FromUUID[T Subtype, PT SubtypePtr[T]](prefix string, uidStr string) (T, error) {
+// FromUUID encodes the given UUID (in hex string form) as a TypeID
+func FromUUID[T Subtype, PT SubtypePtr[T]](uidStr string) (T, error) {
 	uid, err := uuid.FromString(uidStr)
 	var nilID T
 
@@ -107,13 +107,30 @@ func FromUUID[T Subtype, PT SubtypePtr[T]](prefix string, uidStr string) (T, err
 		return nilID, err
 	}
 	suffix := base32.Encode(uid)
-	return from[T, PT](prefix, suffix)
+	return from[T, PT](nilID.Prefix(), suffix)
+}
+
+// FromUUIDBytes encodes the given UUID (in byte form) as a TypeID
+func FromUUIDBytes[T Subtype, PT SubtypePtr[T]](bytes []byte) (T, error) {
+	uidStr := uuid.FromBytesOrNil(bytes).String()
+	return FromUUID[T, PT](uidStr)
+}
+
+// AnyPrefixFromUUID encodes the given UUID (in hex string form) as a TypeID with the given prefix.
+func AnyPrefixFromUUID(prefix string, uidStr string) (AnyID, error) {
+	uid, err := uuid.FromString(uidStr)
+
+	if err != nil {
+		return AnyID{}, err
+	}
+	suffix := base32.Encode(uid)
+	return from[AnyID, *AnyID](prefix, suffix)
 }
 
 // FromUUID encodes the given UUID (in byte form) as a TypeID with the given prefix.
-func FromUUIDBytes[T Subtype, PT SubtypePtr[T]](prefix string, bytes []byte) (T, error) {
+func AnyPrefixFromUUIDBytes(prefix string, bytes []byte) (AnyID, error) {
 	uidStr := uuid.FromBytesOrNil(bytes).String()
-	return FromUUID[T, PT](prefix, uidStr)
+	return AnyPrefixFromUUID(prefix, uidStr)
 }
 
 func from[T Subtype, PT SubtypePtr[T]](prefix string, suffix string) (T, error) {

--- a/typeid/typeid-go/constructors.go
+++ b/typeid/typeid-go/constructors.go
@@ -100,14 +100,7 @@ func split(id string) (string, string, error) {
 
 // FromUUID encodes the given UUID (in hex string form) as a TypeID
 func FromUUID[T Subtype, PT SubtypePtr[T]](uidStr string) (T, error) {
-	uid, err := uuid.FromString(uidStr)
-	var nilID T
-
-	if err != nil {
-		return nilID, err
-	}
-	suffix := base32.Encode(uid)
-	return from[T, PT](nilID.Prefix(), suffix)
+	return fromUUID[T, PT](defaultPrefix[T](), uidStr)
 }
 
 // FromUUIDBytes encodes the given UUID (in byte form) as a TypeID
@@ -116,21 +109,28 @@ func FromUUIDBytes[T Subtype, PT SubtypePtr[T]](bytes []byte) (T, error) {
 	return FromUUID[T, PT](uidStr)
 }
 
-// AnyPrefixFromUUID encodes the given UUID (in hex string form) as a TypeID with the given prefix.
-func AnyPrefixFromUUID(prefix string, uidStr string) (AnyID, error) {
-	uid, err := uuid.FromString(uidStr)
-
-	if err != nil {
-		return AnyID{}, err
-	}
-	suffix := base32.Encode(uid)
-	return from[AnyID, *AnyID](prefix, suffix)
+// FromUUIDWithPrefix encodes the given UUID (in hex string form) as a TypeID
+// with the given prefix.
+func FromUUIDWithPrefix(prefix string, uidStr string) (AnyID, error) {
+	return fromUUID[AnyID](prefix, uidStr)
 }
 
-// FromUUID encodes the given UUID (in byte form) as a TypeID with the given prefix.
-func AnyPrefixFromUUIDBytes(prefix string, bytes []byte) (AnyID, error) {
+// FromUUID encodes the given UUID (in byte form) as a TypeID with the given
+// prefix.
+func FromUUIDBytesWithPrefix(prefix string, bytes []byte) (AnyID, error) {
 	uidStr := uuid.FromBytesOrNil(bytes).String()
-	return AnyPrefixFromUUID(prefix, uidStr)
+	return FromUUIDWithPrefix(prefix, uidStr)
+}
+
+func fromUUID[T Subtype, PT SubtypePtr[T]](prefix, uidStr string) (T, error) {
+	uid, err := uuid.FromString(uidStr)
+	var nilID T
+
+	if err != nil {
+		return nilID, err
+	}
+	suffix := base32.Encode(uid)
+	return from[T, PT](prefix, suffix)
 }
 
 func from[T Subtype, PT SubtypePtr[T]](prefix string, suffix string) (T, error) {

--- a/typeid/typeid-go/prefix.go
+++ b/typeid/typeid-go/prefix.go
@@ -22,12 +22,6 @@ type AnyID struct {
 	TypeID[AnyPrefix]
 }
 
-type DynamicPrefix string
-
-func (a DynamicPrefix) Prefix() string {
-	return string(a)
-}
-
 func isAnyPrefix[P PrefixType]() bool {
 	var prefixType P
 	switch any(prefixType).(type) {

--- a/typeid/typeid-go/prefix.go
+++ b/typeid/typeid-go/prefix.go
@@ -22,6 +22,12 @@ type AnyID struct {
 	TypeID[AnyPrefix]
 }
 
+type DynamicPrefix string
+
+func (a DynamicPrefix) Prefix() string {
+	return string(a)
+}
+
 func isAnyPrefix[P PrefixType]() bool {
 	var prefixType P
 	switch any(prefixType).(type) {

--- a/typeid/typeid-go/subtype_test.go
+++ b/typeid/typeid-go/subtype_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"go.jetpack.io/typeid"
 )
@@ -80,4 +81,20 @@ func TestParse(t *testing.T) {
 		_, err = typeid.Parse[AccountID](tid.String())
 		assert.Error(t, err)
 	}
+}
+
+func TestFromUUID(t *testing.T) {
+	uid, err := uuid.NewV7()
+	assert.NoError(t, err)
+	id, err := typeid.FromUUID[UserID](uid.String())
+	assert.NoError(t, err)
+	assert.Equal(t, uid.String(), id.UUID())
+}
+
+func TestFromUUIDBytes(t *testing.T) {
+	uid, err := uuid.NewV7()
+	assert.NoError(t, err)
+	id, err := typeid.FromUUIDBytes[UserID](uid.Bytes())
+	assert.NoError(t, err)
+	assert.Equal(t, uid.Bytes(), id.UUIDBytes())
 }

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -2,6 +2,7 @@ package typeid_test
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -198,4 +199,14 @@ func TestValidTestdata(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConstructorError(t *testing.T) {
+	_, err := typeid.FromUUID[typeid.AnyID]("00000000-0000-0000-0000-000000000000")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, typeid.ErrConstructor))
+
+	_, err = typeid.FromUUIDBytes[typeid.AnyID]([]byte{0, 0, 0, 0, 0, 0, 0, 0})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, typeid.ErrConstructor))
 }

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -160,7 +160,7 @@ func TestSpecialValues(t *testing.T) {
 			}
 
 			// Values should be equal if we start by parsing the uuid
-			tid = typeid.Must(typeid.AnyPrefixFromUUID("", data.uuid))
+			tid = typeid.Must(typeid.FromUUIDWithPrefix("", data.uuid))
 			if data.tid != tid.String() {
 				t.Errorf("Expected %s, got %s", data.tid, tid.String())
 			}

--- a/typeid/typeid-go/typeid_test.go
+++ b/typeid/typeid-go/typeid_test.go
@@ -160,7 +160,7 @@ func TestSpecialValues(t *testing.T) {
 			}
 
 			// Values should be equal if we start by parsing the uuid
-			tid = typeid.Must(typeid.FromUUID[typeid.AnyID]("", data.uuid))
+			tid = typeid.Must(typeid.AnyPrefixFromUUID("", data.uuid))
 			if data.tid != tid.String() {
 				t.Errorf("Expected %s, got %s", data.tid, tid.String())
 			}

--- a/typeid/typeid/cli/encode.go
+++ b/typeid/typeid/cli/encode.go
@@ -27,7 +27,7 @@ func encodeCmd(cmd *cobra.Command, args []string) error {
 		prefix = args[0]
 		uuid = args[1]
 	}
-	tid, err := typeid.FromUUID[typeid.AnyID](prefix, uuid)
+	tid, err := typeid.AnyPrefixFromUUID(prefix, uuid)
 	if err != nil {
 		return err
 	}

--- a/typeid/typeid/cli/encode.go
+++ b/typeid/typeid/cli/encode.go
@@ -27,7 +27,7 @@ func encodeCmd(cmd *cobra.Command, args []string) error {
 		prefix = args[0]
 		uuid = args[1]
 	}
-	tid, err := typeid.AnyPrefixFromUUID(prefix, uuid)
+	tid, err := typeid.FromUUIDWithPrefix(prefix, uuid)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This change removes the prefix param from `FromUUID` and `FromUUIDBytes`. It follows the philosophy that the correct path should be easy (and the bad path should be less easy).

Previously to convert a UUID you must do:

```golang
// Previously (ugly)
typeid.FromUUID[idType](idType{}.Prefix(), uuid)

// Or potential bug, pass a string
typeid.FromUUID[idType]("typePrefix", uuid)

// After this change
typeid.FromUUID[idType](uuid)
```

Benefits:

* less code in the correct path.
* Much better type checking and less opportunity for miss-use. No way to pass a bad prefix.

Downside:

* AnyIDs are a bit longer and uglier.
* Extra functions

Open to renaming `AnyPrefixFromUUID` to something better. Maybe `FromUUIDWithPrefix` ? or `FromPrefixAndUUID` ?

## How was it tested?

* builds, tests
