### PR TITLE
[JetpackAPIStore] use apiClient

### DIFF
--- a/envsec/envsec.go
+++ b/envsec/envsec.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.jetpack.io/envsec/internal/build"
+	"go.jetpack.io/pkg/auth/session"
 	"go.jetpack.io/pkg/envvar"
 )
 
@@ -116,7 +117,7 @@ func (c *SSMConfig) hasDefaultPaths() bool {
 
 type JetpackAPIConfig struct {
 	host  string
-	token string
+	token *session.Token
 }
 
 // JetpackAPIStore implements interface Config (compile-time check)
@@ -126,7 +127,7 @@ func (c *JetpackAPIConfig) IsEnvStoreConfig() bool {
 	return true
 }
 
-func NewJetpackAPIConfig(token string) *JetpackAPIConfig {
+func NewJetpackAPIConfig(token *session.Token) *JetpackAPIConfig {
 	return &JetpackAPIConfig{
 		envvar.Get("ENVSEC_JETPACK_API_HOST", build.JetpackAPIHost()),
 		token,

--- a/envsec/envsec.go
+++ b/envsec/envsec.go
@@ -64,7 +64,7 @@ func NewStore(ctx context.Context, config Config) (Store, error) {
 	case *SSMConfig:
 		return newSSMStore(ctx, config)
 	case *JetpackAPIConfig:
-		return newJetpackAPIStore(config), nil
+		return newJetpackAPIStore(ctx, config), nil
 	default:
 		return nil, errors.Errorf("unsupported store type: %T", config)
 	}

--- a/envsec/jetpack_api_store.go
+++ b/envsec/jetpack_api_store.go
@@ -16,9 +16,9 @@ type JetpackAPIStore struct {
 // JetpackAPIStore implements interface Store (compile-time check)
 var _ Store = (*JetpackAPIStore)(nil)
 
-func newJetpackAPIStore(config *JetpackAPIConfig) *JetpackAPIStore {
+func newJetpackAPIStore(ctx context.Context, config *JetpackAPIConfig) *JetpackAPIStore {
 	return &JetpackAPIStore{
-		client: api.NewClient(context.Background(), config.host, config.token).SecretsService(),
+		client: api.NewClient(ctx, config.host, config.token).SecretsService(),
 	}
 }
 

--- a/envsec/jetpack_api_store.go
+++ b/envsec/jetpack_api_store.go
@@ -2,28 +2,30 @@ package envsec
 
 import (
 	"context"
-	"net/http"
 
 	"connectrpc.com/connect"
+	"go.jetpack.io/pkg/api"
 	secretsv1alpha1 "go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1"
 	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
 )
 
 type JetpackAPIStore struct {
-	config *JetpackAPIConfig
+	client secretsv1alpha1connect.SecretsServiceClient
 }
 
 // JetpackAPIStore implements interface Store (compile-time check)
 var _ Store = (*JetpackAPIStore)(nil)
 
 func newJetpackAPIStore(config *JetpackAPIConfig) *JetpackAPIStore {
-	return &JetpackAPIStore{config: config}
+	return &JetpackAPIStore{
+		client: api.NewClient(context.Background(), config.host, config.token).SecretsService(),
+	}
 }
 
 func (j JetpackAPIStore) List(ctx context.Context, envID EnvID) ([]EnvVar, error) {
-	resp, err := j.client().ListSecrets(
+	resp, err := j.client.ListSecrets(
 		ctx,
-		newRequest(&secretsv1alpha1.ListSecretsRequest{ProjectId: envID.ProjectID}, j.config.token),
+		connect.NewRequest(&secretsv1alpha1.ListSecretsRequest{ProjectId: envID.ProjectID}),
 	)
 	if err != nil {
 		return nil, err
@@ -43,8 +45,8 @@ func (j JetpackAPIStore) List(ctx context.Context, envID EnvID) ([]EnvVar, error
 }
 
 func (j JetpackAPIStore) Set(ctx context.Context, envID EnvID, name string, value string) error {
-	_, err := j.client().PatchSecret(
-		ctx, newRequest(
+	_, err := j.client.PatchSecret(
+		ctx, connect.NewRequest(
 			&secretsv1alpha1.PatchSecretRequest{
 				ProjectId: envID.ProjectID,
 				Secret: &secretsv1alpha1.Secret{
@@ -54,7 +56,6 @@ func (j JetpackAPIStore) Set(ctx context.Context, envID EnvID, name string, valu
 					},
 				},
 			},
-			j.config.token,
 		),
 	)
 	return err
@@ -80,8 +81,8 @@ func (j JetpackAPIStore) SetAll(ctx context.Context, envID EnvID, values map[str
 		)
 	}
 
-	_, err := j.client().Batch(
-		ctx, newRequest(&secretsv1alpha1.BatchRequest{Actions: patchActions}, j.config.token),
+	_, err := j.client.Batch(
+		ctx, connect.NewRequest(&secretsv1alpha1.BatchRequest{Actions: patchActions}),
 	)
 	return err
 }
@@ -116,14 +117,13 @@ func (j JetpackAPIStore) GetAll(ctx context.Context, envID EnvID, names []string
 }
 
 func (j JetpackAPIStore) Delete(ctx context.Context, envID EnvID, name string) error {
-	_, err := j.client().DeleteSecret(
-		ctx, newRequest(
+	_, err := j.client.DeleteSecret(
+		ctx, connect.NewRequest(
 			&secretsv1alpha1.DeleteSecretRequest{
 				ProjectId:    envID.ProjectID,
 				SecretName:   name,
 				Environments: []string{envID.EnvName},
 			},
-			j.config.token,
 		),
 	)
 	return err
@@ -145,18 +145,8 @@ func (j JetpackAPIStore) DeleteAll(ctx context.Context, envID EnvID, names []str
 		)
 	}
 
-	_, err := j.client().Batch(
-		ctx, newRequest(&secretsv1alpha1.BatchRequest{Actions: deleteActions}, j.config.token),
+	_, err := j.client.Batch(
+		ctx, connect.NewRequest(&secretsv1alpha1.BatchRequest{Actions: deleteActions}),
 	)
 	return err
-}
-
-func (j JetpackAPIStore) client() secretsv1alpha1connect.SecretsServiceClient {
-	return secretsv1alpha1connect.NewSecretsServiceClient(http.DefaultClient, j.config.host)
-}
-
-func newRequest[T any](message *T, token string) *connect.Request[T] {
-	req := connect.NewRequest(message)
-	req.Header().Set("Authorization", "Bearer "+token)
-	return req
 }

--- a/envsec/pkg/envcli/flags.go
+++ b/envsec/pkg/envcli/flags.go
@@ -122,7 +122,7 @@ func (f *configFlags) genConfig(cmd *cobra.Command) (*CmdConfig, error) {
 			return nil, errors.WithStack(err)
 		}
 	} else {
-		store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok.AccessToken))
+		store, err = envsec.NewStore(ctx, envsec.NewJetpackAPIConfig(tok))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -6,6 +6,7 @@ import (
 
 	"go.jetpack.io/pkg/api/gen/priv/members/v1alpha1/membersv1alpha1connect"
 	"go.jetpack.io/pkg/api/gen/priv/projects/v1alpha1/projectsv1alpha1connect"
+	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
 	"go.jetpack.io/pkg/auth/session"
 	"golang.org/x/oauth2"
 )
@@ -13,8 +14,9 @@ import (
 // Client manages state for interacting with the JetCloud API, as well as
 // communicating with the JetCloud API.
 type Client struct {
-	membersClient  func() membersv1alpha1connect.MembersServiceClient
-	projectsClient func() projectsv1alpha1connect.ProjectsServiceClient
+	membersClient        func() membersv1alpha1connect.MembersServiceClient
+	projectsClient       func() projectsv1alpha1connect.ProjectsServiceClient
+	secretsServiceClient func() secretsv1alpha1connect.SecretsServiceClient
 }
 
 func NewClient(ctx context.Context, host string, token *session.Token) *Client {
@@ -30,6 +32,12 @@ func NewClient(ctx context.Context, host string, token *session.Token) *Client {
 		}),
 		projectsClient: sync.OnceValue(func() projectsv1alpha1connect.ProjectsServiceClient {
 			return projectsv1alpha1connect.NewProjectsServiceClient(
+				httpClient,
+				host,
+			)
+		}),
+		secretsServiceClient: sync.OnceValue(func() secretsv1alpha1connect.SecretsServiceClient {
+			return secretsv1alpha1connect.NewSecretsServiceClient(
 				httpClient,
 				host,
 			)

--- a/pkg/api/secrets.go
+++ b/pkg/api/secrets.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"go.jetpack.io/pkg/api/gen/priv/secrets/v1alpha1/secretsv1alpha1connect"
+)
+
+func (c *Client) SecretsService() secretsv1alpha1connect.SecretsServiceClient {
+	return c.secretsServiceClient()
+}


### PR DESCRIPTION
## Summary

This uses the new `apiClient`, which has the benefit of managing the Authorization
header from the token, as well as creating the SecretsService client just once.

I chose to avoid re-defining the SecretsService's methods again. Would prefer
benefitting from the codegen we get and directly using that.

## How was it tested?

`envsec ls` and `envsec set` work as before
