### PR TITLE
[envsec] Fix non-git init and don't offer to link if no projects

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -8,7 +8,7 @@
       "echo 'Welcome to devbox!' > /dev/null"
     ],
     "scripts": {
-      "go-mod-sync": [
+      "tidy": [
         "find . -maxdepth 4 -type f -name go.mod -exec dirname {} \\; | xargs -I {} bash -c \"cd '{}' && echo mod '{}' && go mod tidy\"",
         "go work sync"
       ],

--- a/envsec/internal/flow/init.go
+++ b/envsec/internal/flow/init.go
@@ -64,7 +64,7 @@ func (i *Init) Run(ctx context.Context) (id.ProjectID, error) {
 			return id.ProjectID{}, err
 		}
 		if linkToExisting {
-			return i.showExistingListPrompt(ctx, projects)
+			return i.showExistingListPrompt(projects)
 		}
 	}
 	return i.createNewPrompt(ctx, member)
@@ -96,7 +96,6 @@ func (i *Init) linkToExistingPrompt() (bool, error) {
 }
 
 func (i *Init) showExistingListPrompt(
-	ctx context.Context,
 	projects []*projectsv1alpha1.Project,
 ) (id.ProjectID, error) {
 	repo, err := git.GitRepoURL(i.WorkingDir)

--- a/envsec/internal/flow/init.go
+++ b/envsec/internal/flow/init.go
@@ -49,12 +49,23 @@ func (i *Init) Run(ctx context.Context) (id.ProjectID, error) {
 
 	// TODO: printOrgNotice will be a team picker once that is implemented.
 	i.printOrgNotice(member)
-	linkToExisting, err := i.linkToExistingPrompt()
+	orgID, err := typeid.Parse[id.OrgID](i.Token.IDClaims().OrgID)
 	if err != nil {
 		return id.ProjectID{}, err
 	}
-	if linkToExisting {
-		return i.showExistingListPrompt(ctx)
+
+	projects, err := i.Client.ListProjects(ctx, orgID)
+	if err != nil {
+		return id.ProjectID{}, err
+	}
+	if len(projects) > 0 {
+		linkToExisting, err := i.linkToExistingPrompt()
+		if err != nil {
+			return id.ProjectID{}, err
+		}
+		if linkToExisting {
+			return i.showExistingListPrompt(ctx, projects)
+		}
 	}
 	return i.createNewPrompt(ctx, member)
 }
@@ -86,17 +97,8 @@ func (i *Init) linkToExistingPrompt() (bool, error) {
 
 func (i *Init) showExistingListPrompt(
 	ctx context.Context,
+	projects []*projectsv1alpha1.Project,
 ) (id.ProjectID, error) {
-	orgID, err := typeid.Parse[id.OrgID](i.Token.IDClaims().OrgID)
-	if err != nil {
-		return id.ProjectID{}, err
-	}
-
-	projects, err := i.Client.ListProjects(ctx, orgID)
-	if err != nil {
-		return id.ProjectID{}, err
-	}
-
 	repo, err := git.GitRepoURL(i.WorkingDir)
 	if err != nil {
 		return id.ProjectID{}, err
@@ -154,7 +156,7 @@ func (i *Init) createNewPrompt(
 		Label:   "What’s the name of your new project",
 		Default: filepath.Base(i.WorkingDir),
 		Validate: func(name string) error {
-			if name == "" {
+			if strings.TrimSpace(name) == "" {
 				return errors.New("project name cannot be empty")
 			}
 			return nil
@@ -186,7 +188,7 @@ func (i *Init) createNewPrompt(
 		orgID,
 		repo,
 		directory,
-		name,
+		strings.TrimSpace(name),
 	)
 	if err != nil {
 		return id.ProjectID{}, err

--- a/envsec/internal/git/git.go
+++ b/envsec/internal/git/git.go
@@ -32,6 +32,9 @@ func GitSubdirectory(wd string) (string, error) {
 	cmd.Dir = wd
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if !isInGitRepo(wd) {
+			return "", nil
+		}
 		return "", err
 	}
 	return filepath.Clean(strings.TrimSpace(string(output))), nil


### PR DESCRIPTION
## Summary

* `GitSubdirectory` should not break if not in git repo
* Don't give user option to link projects if there are zero projects
* Trim name when validating 

## How was it tested?
