### PR TITLE
[auth] Add multi-session support for auth pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # TODO(Landau): Turn on all linters
 # TODO(Landau): move this to top level of opensource?
 run:
-  go: "1.20"
+  go: "1.21"
 linters:
   disable-all: true
   enable:
@@ -64,3 +64,6 @@ linters-settings:
       - t testing.T
       - w http.ResponseWriter
       - w io.Writer
+  # TODO: enable this
+  # unparam:
+  #   check-exported: true

--- a/envsec/pkg/envsec/auth.go
+++ b/envsec/pkg/envsec/auth.go
@@ -29,7 +29,7 @@ func (e *Envsec) WhoAmI(
 
 	tok, err := authClient.GetSession(ctx)
 	if err != nil {
-		return fmt.Errorf("error: %w, run `envsec auth login`", err)
+		return err
 	}
 
 	idClaims := tok.IDClaims()

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,41 +78,33 @@ func (c *Client) LogoutFlow() error {
 // expired, it will attempt to refresh it. If no token is found, or is unable
 // to be refreshed, it will return error.
 func (c *Client) GetSession(ctx context.Context) (*session.Token, error) {
-	tok, err := c.store.ReadToken(c.issuer, c.clientID)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, ErrNotLoggedIn
-	} else if err != nil {
+	sources, err := c.GetSessions()
+	if err != nil {
 		return nil, err
 	}
 
-	// Refresh if the token is no longer valid:
-	if !tok.Valid() {
-		tok, err = c.refresh(ctx, tok)
-		if err != nil {
-			return nil, err
-		}
+	if len(sources) == 0 || sources[0].Peek() == nil {
+		return nil, ErrNotLoggedIn
 	}
 
-	return tok, nil
+	return sources[0].Token(ctx)
 }
 
-// GetSessions returns all session tokens as refreshableTokens. This means that
-// they may not be valid or even refreshable. Callers can use Token() to
+// GetSessions returns all session tokens as refreshableTokenSource. This means
+// that they may not be valid or even refreshable. Callers can use Token() to
 // refresh the token if needed. Even if Token() fails to refresh, it still
 // returns the token, so callers can use the expired data if they want.
 // This allows callers to list all sessions, even if they are expired.
 // Callers can use Peek() to inspect token data without refreshing.
-func (c *Client) GetSessions(ctx context.Context) ([]refreshableToken, error) {
+func (c *Client) GetSessions() ([]refreshableTokenSource, error) {
 	tokens, err := c.store.ReadTokens(c.issuer, c.clientID)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, ErrNotLoggedIn
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 
-	refreshableTokens := []refreshableToken{}
+	refreshableTokens := []refreshableTokenSource{}
 	for _, tok := range tokens {
-		refreshableTokens = append(refreshableTokens, refreshableToken{
+		refreshableTokens = append(refreshableTokens, refreshableTokenSource{
 			client: c,
 			token:  tok,
 		})

--- a/pkg/auth/internal/tokenstore/io.go
+++ b/pkg/auth/internal/tokenstore/io.go
@@ -26,7 +26,7 @@ func ensureDir(path string) error {
 	return os.MkdirAll(dir, 0700)
 }
 
-func writeJSONFile(path string, value any) error {
+func writeJSONFile(path string, value storeData) error {
 	err := ensureDir(path)
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func writeJSONFile(path string, value any) error {
 	return errors.WithStack(os.WriteFile(path, data, 0644))
 }
 
-func readJSONFile(path string, value any) error {
+func readJSONFile(path string, value *storeData) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/auth/internal/tokenstore/tokenstore.go
+++ b/pkg/auth/internal/tokenstore/tokenstore.go
@@ -7,8 +7,15 @@ import (
 	"go.jetpack.io/pkg/auth/session"
 )
 
+const storeDataVersion = "1"
+
 type Store struct {
 	rootDir string
+}
+
+type storeData struct {
+	Version string           `json:"version"`
+	Tokens  []*session.Token `json:"tokens"`
 }
 
 func New(rootDir string) (*Store, error) {
@@ -23,14 +30,43 @@ func New(rootDir string) (*Store, error) {
 	}, nil
 }
 
+// ReadToken returns the top token for the given issuer and clientID.
+// Top token was the last token written to the store. (last login/refresh)
 func (s *Store) ReadToken(issuer string, clientID string) (*session.Token, error) {
-	var tok session.Token
-	path := s.path(issuer, clientID)
-	err := readJSONFile(path, &tok)
+	data, err := s.readData(issuer, clientID)
 	if err != nil {
 		return nil, err
 	}
-	return &tok, nil
+	if len(data.Tokens) == 0 {
+		return nil, os.ErrNotExist
+	}
+	return data.Tokens[0], nil
+}
+
+func (s *Store) ReadTokens(issuer string, clientID string) ([]*session.Token, error) {
+	data, err := s.readData(issuer, clientID)
+	if err != nil {
+		return nil, err
+	}
+	return data.Tokens, nil
+}
+
+// FindToken returns the first token for the given issuer and clientID where
+// fn returns true.
+func (s *Store) FindToken(
+	issuer, clientID string,
+	fn func(tok *session.Token) bool,
+) (*session.Token, error) {
+	tokens, err := s.ReadTokens(issuer, clientID)
+	if err != nil {
+		return nil, err
+	}
+	for _, tok := range tokens {
+		if fn(tok) {
+			return tok, nil
+		}
+	}
+	return nil, os.ErrNotExist
 }
 
 func (s *Store) WriteToken(issuer string, clientID string, tok *session.Token) error {
@@ -38,8 +74,16 @@ func (s *Store) WriteToken(issuer string, clientID string, tok *session.Token) e
 		// A nil token is the same as deleting the token.
 		return s.DeleteToken(issuer, clientID)
 	}
+	data, err := s.readData(issuer, clientID)
+	if err != nil {
+		return err
+	}
+	data.addToken(tok)
 	path := s.path(issuer, clientID)
-	return writeJSONFile(path, tok)
+	return writeJSONFile(
+		path,
+		data,
+	)
 }
 
 func (s *Store) DeleteToken(issuer string, clientID string) error {
@@ -52,4 +96,26 @@ func (s *Store) DeleteToken(issuer string, clientID string) error {
 	}
 
 	return os.Remove(path)
+}
+
+func (s *Store) readData(issuer, clientID string) (storeData, error) {
+	path := s.path(issuer, clientID)
+	var data storeData
+	err := readJSONFile(path, &data)
+	if errors.Is(err, os.ErrNotExist) {
+		return storeData{Version: storeDataVersion}, nil
+	} else if err != nil {
+		return storeData{Version: storeDataVersion}, err
+	}
+	return data, nil
+}
+
+func (sd *storeData) addToken(tok *session.Token) {
+	tokens := []*session.Token{tok}
+	for _, t := range sd.Tokens {
+		if t.IDClaims().Subject != tok.IDClaims().Subject {
+			tokens = append(tokens, t)
+		}
+	}
+	sd.Tokens = tokens
 }

--- a/pkg/auth/internal/tokenstore/tokenstore.go
+++ b/pkg/auth/internal/tokenstore/tokenstore.go
@@ -15,8 +15,7 @@ type Store struct {
 
 type storeData struct {
 	Version string `json:"version"`
-	// Token order is significant. The first token is the most recent and
-	// returned by ReadToken.
+	// Token order is significant. The first token is the default token.
 	Tokens []*session.Token `json:"tokens"`
 }
 
@@ -30,19 +29,6 @@ func New(rootDir string) (*Store, error) {
 	return &Store{
 		rootDir: rootDir,
 	}, nil
-}
-
-// ReadToken returns the top token for the given issuer and clientID.
-// Top token was the last token written to the store. (last login/refresh)
-func (s *Store) ReadToken(issuer string, clientID string) (*session.Token, error) {
-	data, err := s.readData(issuer, clientID)
-	if err != nil {
-		return nil, err
-	}
-	if len(data.Tokens) == 0 {
-		return nil, os.ErrNotExist
-	}
-	return data.Tokens[0], nil
 }
 
 func (s *Store) ReadTokens(issuer string, clientID string) ([]*session.Token, error) {

--- a/pkg/auth/refreshable.go
+++ b/pkg/auth/refreshable.go
@@ -7,18 +7,20 @@ import (
 )
 
 // Implements something similar to oauth2.TokenSource, but with a session.Token
-type refreshableToken struct {
+type refreshableTokenSource struct {
 	client *Client
 	token  *session.Token
 }
 
-func (t *refreshableToken) Token(ctx context.Context) (*session.Token, error) {
+func (t *refreshableTokenSource) Token(
+	ctx context.Context,
+) (*session.Token, error) {
 	if !t.token.Valid() {
 		return t.client.refresh(ctx, t.token)
 	}
 	return t.token, nil
 }
 
-func (t *refreshableToken) Peek() *session.Token {
+func (t *refreshableTokenSource) Peek() *session.Token {
 	return t.token
 }

--- a/pkg/auth/refreshable.go
+++ b/pkg/auth/refreshable.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"context"
+
+	"go.jetpack.io/pkg/auth/session"
+)
+
+// Implements something similar to oauth2.TokenSource, but with a session.Token
+type refreshableToken struct {
+	client *Client
+	token  *session.Token
+}
+
+func (t *refreshableToken) Token(ctx context.Context) (*session.Token, error) {
+	if !t.token.Valid() {
+		return t.client.refresh(ctx, t.token)
+	}
+	return t.token, nil
+}
+
+func (t *refreshableToken) Peek() *session.Token {
+	return t.token
+}


### PR DESCRIPTION
## Summary

Adds multi-session support to auth. 

* Every time a user logs in, we prepend the token to the token slice. We always dedup by subject, so if there's any existing token that matches that subject, we remove it.
* Added `GetSessions` function. `GetSessions` returns refreshable tokens, instead of tokens. This allows the caller to inspect each token to find which one they want without having to refresh all. It also allows them to do useful stuff if only some tokens refresh successfully. 
* Session tokens are saved in a json file that contains a version.
* Logout removes all tokens.
* These changes are fully backwards compatible (which the exception that they will consider current users to be logged out, so they will require a single login on upgrade)

This will support allowing envsec to:

* Initialize a project in any org you are logged in to.
* Automatically use the correct token if you are logged in to multiple orgs and have projects in multiple orgs.

## How was it tested?

`envsec auth login`
