### PR TITLE
[cicd] Add 10s sleep to insure update dependencies gets latest

### DIFF
--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -57,6 +57,9 @@ jobs:
     needs: publish-repos
     runs-on: ubuntu-latest
     steps:
+      - name: Sleep 10s to ensure latest repos get pulled
+        run: sleep 10s
+
       - name: Checkout Monorepo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary

This job seems to update the previous go dependencies. Added a 10s delay to see if it's fixed. If this doesn't work, we can pull a specific hash, but that is more work.

## How was it tested?

Will test in prod CICD