### PR TITLE
[CICD] Improve CICD caching

### DIFF
--- a/.github/workflows/monorepo-go.yml
+++ b/.github/workflows/monorepo-go.yml
@@ -31,6 +31,8 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg
           key: ${{ runner.os }}-${{ hashFiles('**/*.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       # Disable this check until we figure out how to solve for
       # the 'publish repos twice' problem

--- a/envsec/.github/workflows/release.yml
+++ b/envsec/.github/workflows/release.yml
@@ -29,6 +29,18 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
+          cache: false
+      
+      - name: Mount golang cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg
+          key: ${{ runner.os }}-release-${{ hashFiles('**/*.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
 
       - name: Release with goreleaser
         uses: goreleaser/goreleaser-action@v5

--- a/envsec/.github/workflows/tests.yml
+++ b/envsec/.github/workflows/tests.yml
@@ -28,7 +28,10 @@ jobs:
             ~/.cache/golangci-lint
             ~/.cache/go-build
             ~/go/pkg
-          key: ${{ runner.os }}-${{ hashFiles('**/*.sum') }}
+          key: ${{ runner.os }}-tests-${{ hashFiles('**/*.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-tests
+            ${{ runner.os }}
 
       - name: Build
         run: devbox run build


### PR DESCRIPTION
## Summary

Since our dependencies change quite a bit, using `restore-keys` allows us to leverage previews caches that may not be exact matches.

## How was it tested?

CICD
