### PR TITLE
Sort secrets before displaying them

### DIFF
--- a/envsec/pkg/envsec/list.go
+++ b/envsec/pkg/envsec/list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -34,8 +35,9 @@ func PrintEnvVar(
 			Name:  envVar.Name,
 			Value: valueToPrint,
 		})
-
 	}
+
+	slices.SortFunc(envVarsMaskedValue, func(a EnvVar, b EnvVar) int { return strings.Compare(a.Name, b.Name) })
 
 	switch format {
 	case "table":


### PR DESCRIPTION
## Summary
Otherwise the secrets are displayed in a non-deterministic order. It feels weird that repeated calls to `envsec ls` result in different outputs. Also alphabetizing makes it easier to find secrets in large lists (like dashboard).

## How was it tested?
In progress.