### PR TITLE
Typed `toString()`.

### DIFF
--- a/typeid/typeid-js/src/typeid.ts
+++ b/typeid/typeid-js/src/typeid.ts
@@ -70,7 +70,7 @@ export class TypeID<const T extends string> {
     return uuid.toString();
   }
 
-  public toString(): string {
+  public toString(): `${T}_${string}` | string {
     if (this.prefix === "") {
       return this.suffix;
     }


### PR DESCRIPTION
## Summary

This PR only changes the type value of `toString()` in typeid-js to allow for the usage of template string types.

## Example

```ts
export type UserTypeString = `user_${string}`;
export type UserTypeID = TypeID<'user'>;

private connectedUsers: Record<UserTypeString, User> = {};

const userId = user.id.toString();
connectedUsers[userId] = user;
```

This code will fail type checking if `user.id.toString()` returns a string that doesn't start with `user_`. This adds a bit of type safety, but it also makes the code more readable -- when you look at the `connectedUsers` Record, you know _exactly_ what it's keyed by, not just a generic `string`.

Without this change, you instead have to typecast that `toString()` everywhere:

```
const userId = user.id.toString as UserTypeString;
```

Doable, but ugly.  =)

## How was it tested?

All tests pass, and I've been using a locally-linked version of this in my project for a while now with no issues.