### PR TITLE
[auth] Add audience to auth package

### DIFF
--- a/envsec/internal/build/build.go
+++ b/envsec/internal/build/build.go
@@ -32,6 +32,10 @@ func Issuer() string {
 	return "https://accounts.jetpack.io"
 }
 
+func Audience() string {
+	return "https://api.jetpack.io"
+}
+
 func ClientID() string {
 	if IsDev {
 		return "3945b320-bd31-4313-af27-846b67921acb"

--- a/envsec/pkg/envcli/auth.go
+++ b/envsec/pkg/envcli/auth.go
@@ -111,5 +111,6 @@ func newAuthClient() (*auth.Client, error) {
 		clientID,
 		[]string{"openid", "offline_access", "email", "profile"},
 		envvar.Get("ENVSEC_SUCCESS_REDIRECT", build.SuccessRedirect()),
+		[]string{envvar.Get("ENVSEC_AUDIENCE", build.Audience())},
 	)
 }

--- a/envsec/pkg/envcli/init.go
+++ b/envsec/pkg/envcli/init.go
@@ -41,16 +41,17 @@ func initCmd() *cobra.Command {
 	return command
 }
 
-func defaultEnvsec(cmd *cobra.Command, wd string) *envsec.Envsec {
+func defaultEnvsec(cmd *cobra.Command, workingDir string) *envsec.Envsec {
 	return &envsec.Envsec{
 		APIHost: build.JetpackAPIHost(),
 		Auth: envsec.AuthConfig{
+			Audience:        []string{envvar.Get("ENVSEC_AUDIENCE", build.Audience())},
 			ClientID:        envvar.Get("ENVSEC_CLIENT_ID", build.ClientID()),
 			Issuer:          envvar.Get("ENVSEC_ISSUER", build.Issuer()),
 			SuccessRedirect: envvar.Get("ENVSEC_SUCCESS_REDIRECT", build.SuccessRedirect()),
 		},
 		IsDev:      build.IsDev,
 		Stderr:     cmd.ErrOrStderr(),
-		WorkingDir: wd,
+		WorkingDir: workingDir,
 	}
 }

--- a/envsec/pkg/envsec/auth.go
+++ b/envsec/pkg/envsec/auth.go
@@ -15,6 +15,7 @@ func (e *Envsec) AuthClient() (*auth.Client, error) {
 		e.Auth.ClientID,
 		[]string{"openid", "offline_access", "email", "profile"},
 		e.Auth.SuccessRedirect,
+		e.Auth.Audience,
 	)
 }
 

--- a/envsec/pkg/envsec/envsec.go
+++ b/envsec/pkg/envsec/envsec.go
@@ -18,6 +18,7 @@ type Envsec struct {
 }
 
 type AuthConfig struct {
+	Audience        []string
 	Issuer          string
 	ClientID        string
 	SuccessRedirect string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -18,6 +18,7 @@ import (
 var ErrNotLoggedIn = fmt.Errorf("not logged in")
 
 type Client struct {
+	audience        []string
 	issuer          string
 	clientID        string
 	store           *tokenstore.Store
@@ -29,6 +30,7 @@ func NewClient(
 	issuer, clientID string,
 	scopes []string,
 	successRedirect string,
+	audience []string,
 ) (*Client, error) {
 	store, err := tokenstore.New(storeDir())
 	if err != nil {
@@ -36,6 +38,7 @@ func NewClient(
 	}
 
 	return &Client{
+		audience:        audience,
 		issuer:          issuer,
 		clientID:        clientID,
 		scopes:          scopes,
@@ -53,7 +56,7 @@ func storeDir() string {
 }
 
 func (c *Client) LoginFlow() (*session.Token, error) {
-	tok, err := c.login(c.issuer, c.clientID, c.scopes)
+	tok, err := c.login()
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +183,8 @@ func (c *Client) RevokeSession() error {
 	return c.store.DeleteToken(c.issuer, c.clientID)
 }
 
-func (c *Client) login(issuer string, clientID string, scopes []string) (*session.Token, error) {
-	flow, err := authflow.New(issuer, clientID, scopes)
+func (c *Client) login() (*session.Token, error) {
+	flow, err := authflow.New(c.issuer, c.clientID, c.scopes, c.audience)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/cmd/auth/cli/login.go
+++ b/pkg/auth/cmd/auth/cli/login.go
@@ -50,6 +50,7 @@ func login(issuer, clientID string) error {
 		clientID,
 		[]string{"openid", "offline_access", "email", "profile"},
 		"",
+		[]string{}, // audience
 	)
 	if err != nil {
 		return err

--- a/pkg/auth/internal/authflow/authflow.go
+++ b/pkg/auth/internal/authflow/authflow.go
@@ -13,6 +13,7 @@ import (
 type AuthFlow struct {
 	URL string
 
+	audience []string
 	issuer   string
 	clientID string
 	scopes   []string
@@ -25,11 +26,12 @@ type AuthFlow struct {
 	oidcProvider *oidc.Provider
 }
 
-func New(issuer string, clientID string, scopes []string) (*AuthFlow, error) {
+func New(issuer string, clientID string, scopes []string, audience []string) (*AuthFlow, error) {
 	// TODO: We currently default to using the Auth flow with PCKE
 	// we could instead check if the issuer supports the device flow, if
 	// it does, use that, otherwise use the PKCE flow.
 	flow := &AuthFlow{
+		audience: audience,
 		issuer:   issuer,
 		clientID: clientID,
 		scopes:   scopes,

--- a/pkg/auth/internal/authflow/url.go
+++ b/pkg/auth/internal/authflow/url.go
@@ -1,6 +1,8 @@
 package authflow
 
 import (
+	"strings"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"go.jetpack.io/pkg/auth/internal/pkce"
 	"golang.org/x/oauth2"
@@ -15,5 +17,10 @@ func (f *AuthFlow) authURL() string {
 func (f *AuthFlow) authURLParams() []oauth2.AuthCodeOption {
 	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline, oidc.Nonce(f.oidcNonce)}
 	opts = append(opts, pkce.S256ChallengeOption(f.pkceCodeVerifier)...)
+	if len(f.audience) > 0 {
+		// Audience is not a standard OAuth2 parameter, we follow ory/hydra's convention
+		// https://www.ory.sh/docs/hydra/guides/audiences#audience-in-authorization-code-implicit-and-hybrid-flows
+		opts = append(opts, oauth2.SetAuthURLParam("audience", strings.Join(f.audience, " ")))
+	}
 	return opts
 }


### PR DESCRIPTION
## Summary

TSIA.

Audience is non-standard, but is required and supported by ory.

This is needed to use tokens for identity federation with AWS.

## How was it tested?

```
envsec auth login
envsec auth whoami --show-tokens
```

